### PR TITLE
fix foreign key issue due to bug in clusterj

### DIFF
--- a/src/main/java/io/hops/metadata/ndb/dalimpl/yarn/AppSchedulingInfoClusterJ.java
+++ b/src/main/java/io/hops/metadata/ndb/dalimpl/yarn/AppSchedulingInfoClusterJ.java
@@ -106,6 +106,7 @@ public class AppSchedulingInfoClusterJ implements
     AppSchedulingInfoClusterJ.AppSchedulingInfoDTO persistable =
         createPersistable(toAdd, session);
     session.savePersistent(persistable);
+    session.flush();
   }
   
   public void remove(AppSchedulingInfo toRemove) throws StorageException {

--- a/src/main/java/io/hops/metadata/ndb/dalimpl/yarn/FiCaSchedulerNodeClusterJ.java
+++ b/src/main/java/io/hops/metadata/ndb/dalimpl/yarn/FiCaSchedulerNodeClusterJ.java
@@ -68,6 +68,7 @@ public class FiCaSchedulerNodeClusterJ implements
     HopsSession session = connector.obtainSession();
     FiCaSchedulerNodeDTO persistable = createPersistable(toAdd, session);
     session.savePersistent(persistable);
+    session.flush();
   }
 
   @Override
@@ -79,9 +80,9 @@ public class FiCaSchedulerNodeClusterJ implements
     for (FiCaSchedulerNode hop : toAdd) {
       FiCaSchedulerNodeDTO persistable = createPersistable(hop, session);
       toPersist.add(persistable);
-
-      session.savePersistentAll(toPersist);
     }
+      session.savePersistentAll(toPersist);
+      session.flush();
   }
 
   @Override

--- a/src/main/java/io/hops/metadata/ndb/dalimpl/yarn/RMContainerClusterJ.java
+++ b/src/main/java/io/hops/metadata/ndb/dalimpl/yarn/RMContainerClusterJ.java
@@ -118,6 +118,7 @@ public class RMContainerClusterJ
     }
 
     session.savePersistentAll(toPersist);
+    session.flush();
   }
 
   @Override
@@ -138,6 +139,7 @@ public class RMContainerClusterJ
   public void add(RMContainer rmcontainer) throws StorageException {
     HopsSession session = connector.obtainSession();
     session.savePersistent(createPersistable(rmcontainer, session));
+    session.flush();
   }
 
   private RMContainer createHopRMContainer(RMContainerDTO rMContainerDTO) {

--- a/src/main/java/io/hops/metadata/ndb/dalimpl/yarn/SchedulerApplicationClusterJ.java
+++ b/src/main/java/io/hops/metadata/ndb/dalimpl/yarn/SchedulerApplicationClusterJ.java
@@ -88,6 +88,7 @@ public class SchedulerApplicationClusterJ
       toPersist.add(createPersistable(req, session));
     }
     session.savePersistentAll(toPersist);
+    session.flush();
   }
 
   @Override

--- a/src/main/java/io/hops/metadata/ndb/dalimpl/yarn/rmstatestore/ApplicationStateClusterJ.java
+++ b/src/main/java/io/hops/metadata/ndb/dalimpl/yarn/rmstatestore/ApplicationStateClusterJ.java
@@ -115,6 +115,7 @@ public class ApplicationStateClusterJ implements
       toPersist.add(createPersistable(req, session));
     }
     session.savePersistentAll(toPersist);
+    session.flush();
   }
 
   @Override
@@ -133,6 +134,7 @@ public class ApplicationStateClusterJ implements
   public void add(ApplicationState toAdd) throws StorageException {
     HopsSession session = connector.obtainSession();
     session.savePersistent(createPersistable(toAdd, session));
+    session.flush();
   }
 
   @Override


### PR DESCRIPTION
Add session.flush when persisting potential parent row to avoid to have "foreign key violation" when committing parent and child rows in the same transaction.

resolve #5