### PR TITLE
resolve problems introduced by the quota scheduler

### DIFF
--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -1081,7 +1081,8 @@ CREATE TABLE `yarn_containers_logs` (
   `stop` BIGINT  DEFAULT NULL,
   `exit_status` INT  DEFAULT NULL,
   PRIMARY KEY (`container_id`))
-ENGINE = ndbcluster PARTITION BY KEY(container_id)$$
+ENGINE = ndbcluster $$
+#PARTITION BY KEY(container_id)$$
 
 delimiter $$
 

--- a/src/main/java/io/hops/metadata/ndb/dalimpl/yarn/ContainersLogsClusterJ.java
+++ b/src/main/java/io/hops/metadata/ndb/dalimpl/yarn/ContainersLogsClusterJ.java
@@ -80,6 +80,7 @@ public class ContainersLogsClusterJ implements
     }
 
     session.deletePersistentAll(toRemove);
+    session.flush();
     session.release(toRemove);
   }
   

--- a/src/main/java/io/hops/metadata/ndb/dalimpl/yarn/NextHeartbeatClusterJ.java
+++ b/src/main/java/io/hops/metadata/ndb/dalimpl/yarn/NextHeartbeatClusterJ.java
@@ -111,8 +111,10 @@ public class NextHeartbeatClusterJ
       }
     }
     session.savePersistentAll(toPersist);
-    session.release(toPersist);
+    session.flush();
     session.deletePersistentAll(toRemove);
+    session.flush();
+    session.release(toPersist);
     session.release(toRemove);
   }
 


### PR DESCRIPTION
The quota scheduler as it is now is introducing a high load on the database, this should be resolved by changing the implementation to use the streaming library. In the mean time some quick fixes allow us to reduce its impact