### PR TITLE
correct capacity scheduler recovery

### DIFF
--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -1226,3 +1226,11 @@ CREATE TABLE `yarn_allocate_rpc_resource_increase` (
     ON DELETE CASCADE
     ON UPDATE NO ACTION)
 ENGINE = ndbcluster PARTITION BY KEY(rpcid)$$
+
+delimiter $$
+
+CREATE TABLE `yarn_cs_leaf_queue_pending_apps` (
+  `app_attempt_id` varchar(200) NOT NULL,
+  `path` varchar(200) NOT NULL,
+  PRIMARY KEY (`app_attempt_id`))
+ENGINE = ndbcluster PARTITION BY KEY(app_attempt_id)$$

--- a/src/main/java/io/hops/metadata/ndb/ClusterjConnector.java
+++ b/src/main/java/io/hops/metadata/ndb/ClusterjConnector.java
@@ -112,6 +112,7 @@ import io.hops.metadata.yarn.dal.UpdatedContainerInfoDataAccess;
 import io.hops.metadata.yarn.dal.YarnProjectsDailyCostDataAccess;
 import io.hops.metadata.yarn.dal.YarnProjectsQuotaDataAccess;
 import io.hops.metadata.yarn.dal.YarnVariablesDataAccess;
+import io.hops.metadata.yarn.dal.capacity.CSLeafQueuesPendingAppsDataAccess;
 import io.hops.metadata.yarn.dal.capacity.CSQueueDataAccess;
 import io.hops.metadata.yarn.dal.capacity.FiCaSchedulerAppReservedContainersDataAccess;
 import io.hops.metadata.yarn.dal.fair.LocalityLevelDataAccess;
@@ -418,7 +419,8 @@ public class ClusterjConnector implements StorageConnector<DBSession> {
         NextHeartbeatDataAccess.class,
         NodeHBResponseDataAccess.class, 
         YarnProjectsQuotaDataAccess.class, YarnProjectsDailyCostDataAccess.class,
-            ContainersCheckPointsDataAccess.class);
+        ContainersCheckPointsDataAccess.class,
+        CSLeafQueuesPendingAppsDataAccess.class);
   }
 
   private boolean format(boolean transactional,
@@ -688,6 +690,8 @@ public class ClusterjConnector implements StorageConnector<DBSession> {
             truncate(transactional, io.hops.metadata.yarn.TablesDef.RunnableAppsTableDef.TABLE_NAME);
           } else if (e==CSQueueDataAccess.class){
             truncate(transactional, io.hops.metadata.yarn.TablesDef.CSQueueTableDef.TABLE_NAME);
+          } else if (e==CSLeafQueuesPendingAppsDataAccess.class){
+            truncate(transactional, io.hops.metadata.yarn.TablesDef.CSLeafQueuesPendingAppsTableDef.TABLE_NAME);
           }
         }
         MysqlServerConnector.truncateTable(transactional,

--- a/src/main/java/io/hops/metadata/ndb/NdbStorageFactory.java
+++ b/src/main/java/io/hops/metadata/ndb/NdbStorageFactory.java
@@ -120,6 +120,7 @@ import io.hops.metadata.ndb.dalimpl.yarn.FiCaSchedulerAppSchedulingOpportunities
 import io.hops.metadata.ndb.dalimpl.yarn.YarnProjectsDailyCostClusterJ;
 import io.hops.metadata.ndb.dalimpl.yarn.YarnProjectsQuotaClusterJ;
 import io.hops.metadata.ndb.dalimpl.yarn.capacity.CSLeafQueueUserInfoClusterJ;
+import io.hops.metadata.ndb.dalimpl.yarn.capacity.CSLeafQueuesPendingAppsClusterJ;
 import io.hops.metadata.ndb.dalimpl.yarn.capacity.CSQueueClusterJ;
 import io.hops.metadata.ndb.dalimpl.yarn.fair.FSSchedulerNodeClusterJ;
 import io.hops.metadata.ndb.dalimpl.yarn.fair.LocalityLevelClusterJ;
@@ -177,6 +178,7 @@ import io.hops.metadata.yarn.dal.FiCaSchedulerAppSchedulingOpportunitiesDataAcce
 import io.hops.metadata.yarn.dal.YarnProjectsDailyCostDataAccess;
 import io.hops.metadata.yarn.dal.YarnProjectsQuotaDataAccess;
 import io.hops.metadata.yarn.dal.capacity.CSLeafQueueUserInfoDataAccess;
+import io.hops.metadata.yarn.dal.capacity.CSLeafQueuesPendingAppsDataAccess;
 import io.hops.metadata.yarn.dal.capacity.CSQueueDataAccess;
 import io.hops.metadata.yarn.dal.fair.FSSchedulerNodeDataAccess;
 import io.hops.metadata.yarn.dal.fair.LocalityLevelDataAccess;
@@ -358,7 +360,8 @@ public class NdbStorageFactory implements DalStorageFactory {
     dataAccessMap.put(UserDataAccess.class, new UserClusterj());
     dataAccessMap.put(GroupDataAccess.class, new GroupClusterj());
     dataAccessMap.put(UserGroupDataAccess.class, new UserGroupClusterj());
-    
+    dataAccessMap.put(CSLeafQueuesPendingAppsDataAccess.class,
+            new CSLeafQueuesPendingAppsClusterJ());
     // Quota Scheduling
     dataAccessMap.put(YarnProjectsQuotaDataAccess.class, new YarnProjectsQuotaClusterJ());
     dataAccessMap.put(YarnProjectsDailyCostDataAccess.class, new YarnProjectsDailyCostClusterJ());

--- a/src/main/java/io/hops/metadata/ndb/dalimpl/yarn/capacity/CSLeafQueuesPendingAppsClusterJ.java
+++ b/src/main/java/io/hops/metadata/ndb/dalimpl/yarn/capacity/CSLeafQueuesPendingAppsClusterJ.java
@@ -1,0 +1,115 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+
+package io.hops.metadata.ndb.dalimpl.yarn.capacity;
+
+import com.mysql.clusterj.annotation.Column;
+import com.mysql.clusterj.annotation.PersistenceCapable;
+import com.mysql.clusterj.annotation.PrimaryKey;
+import io.hops.exception.StorageException;
+import io.hops.metadata.ndb.ClusterjConnector;
+import io.hops.metadata.ndb.wrapper.HopsQuery;
+import io.hops.metadata.ndb.wrapper.HopsQueryBuilder;
+import io.hops.metadata.ndb.wrapper.HopsQueryDomainType;
+import io.hops.metadata.ndb.wrapper.HopsSession;
+import io.hops.metadata.yarn.TablesDef;
+import io.hops.metadata.yarn.dal.capacity.CSLeafQueuesPendingAppsDataAccess;
+import io.hops.metadata.yarn.entity.capacity.LeafQueuePendingApp;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class CSLeafQueuesPendingAppsClusterJ implements TablesDef.CSLeafQueuesPendingAppsTableDef,
+        CSLeafQueuesPendingAppsDataAccess<LeafQueuePendingApp>{
+
+  private final ClusterjConnector connector = ClusterjConnector.getInstance();
+
+  @PersistenceCapable(table = TABLE_NAME)
+  public interface LeafQueuePendingAppDTO {
+
+    @PrimaryKey
+    @Column(name = APPATTEMPTID)
+    String getAppAttemptId();
+
+    void setAppAttemptId(String appAttemptId);
+
+    
+    @Column(name = PATH)
+    String getpath();
+
+    void setpath(String path);
+  }
+  
+  @Override
+  public Map<String, Set<String>> getAll() throws StorageException, IOException {
+    HopsSession session = connector.obtainSession();
+    HopsQueryBuilder qb = session.getQueryBuilder();
+    HopsQueryDomainType<LeafQueuePendingAppDTO> dobj = qb.
+            createQueryDefinition(LeafQueuePendingAppDTO.class);
+    HopsQuery<LeafQueuePendingAppDTO> query = session.createQuery(dobj);
+    List<LeafQueuePendingAppDTO> queryResults = query.getResultList();
+
+    Map<String, Set<String>> result = createMap(queryResults);
+    session.release(queryResults);
+    return result;
+  }
+  
+  @Override
+  public void addAll(Collection<LeafQueuePendingApp> modified) throws StorageException {
+    HopsSession session = connector.obtainSession();
+    if (modified != null) {
+      List<LeafQueuePendingAppDTO> toModify = new ArrayList<LeafQueuePendingAppDTO>(modified.size());
+      for (LeafQueuePendingApp hop : modified) {
+        toModify.add(createPersistable(hop, session));
+      }
+      session.savePersistentAll(toModify);
+      session.release(toModify);
+    }
+  }
+
+  @Override
+  public void removeAll(Collection<LeafQueuePendingApp> removed) throws StorageException {
+    HopsSession session = connector.obtainSession();
+    if (removed != null) {
+      List<LeafQueuePendingAppDTO> toRemove = new ArrayList<LeafQueuePendingAppDTO>(removed.size());
+      for (LeafQueuePendingApp hop : removed) {
+        toRemove.add(createPersistable(hop, session));
+      }
+      session.deletePersistentAll(toRemove);
+      session.release(toRemove);
+    }
+  }
+  
+  private LeafQueuePendingAppDTO createPersistable(LeafQueuePendingApp hop, HopsSession session) throws
+          StorageException {
+    LeafQueuePendingAppDTO dto = session.newInstance(
+            LeafQueuePendingAppDTO.class);
+
+    dto.setAppAttemptId(hop.getAppAttemptId());
+    dto.setpath(hop.getQueuePath());
+
+    return dto;
+  }
+  
+  private Map<String,Set<String>> createMap(List<LeafQueuePendingAppDTO> list)
+          throws IOException {
+    Map<String, Set<String>> map = new HashMap<String,Set<String>>();
+    for (LeafQueuePendingAppDTO persistable : list) {
+      Set<String> set = map.get(persistable.getpath());
+      if(set==null){
+        set = new HashSet<String>();
+        map.put(persistable.getpath(), set);
+      }
+      set.add(persistable.getAppAttemptId());
+    }
+    return map;
+  }
+}

--- a/src/main/java/io/hops/metadata/ndb/dalimpl/yarn/capacity/CSQueueClusterJ.java
+++ b/src/main/java/io/hops/metadata/ndb/dalimpl/yarn/capacity/CSQueueClusterJ.java
@@ -146,7 +146,7 @@ public class CSQueueClusterJ implements TablesDef.CSQueueTableDef,
     if (removed != null) {
       List<CSQueueDTO> toRemove = new ArrayList<CSQueueDTO>(removed.size());
       for (CSQueue hop : removed) {
-        toRemove.add(session.newInstance(CSQueueClusterJ.CSQueueDTO.class));
+        toRemove.add(createPersistable(hop, session));
       }
       session.deletePersistentAll(toRemove);
       session.release(toRemove);


### PR DESCRIPTION
When recovering leafQueue the recover function was unsing appAttempt isPending to decide to put the application in the pending queue or in the active queue but appAttempt.isPending and the leafQueue pending queue are not linked, introducing a new mechanism to persist the pending queue in the database