### PR TITLE
Remove foreign keys for tables in NDB

### DIFF
--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -693,12 +693,7 @@ CREATE TABLE `yarn_rmnode_finishedapplications` (
   `applicationid` VARCHAR(45) NOT NULL,
   `pendingeventid` INT,
   PRIMARY KEY (`rmnodeid`, `applicationid`),
-  INDEX `index2` (`rmnodeid` ASC),
-  CONSTRAINT `rmnodeid`
-    FOREIGN KEY (`rmnodeid`)
-    REFERENCES `yarn_rmnode` (`rmnodeid`)
-    ON DELETE CASCADE
-    ON UPDATE NO ACTION
+  INDEX `index2` (`rmnodeid` ASC)
 ) ENGINE=ndbcluster DEFAULT CHARSET=latin1 PARTITION BY KEY(applicationid) $$
 
 

--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -947,12 +947,7 @@ CREATE TABLE `yarn_nextheartbeat` (
   `rmnodeid` VARCHAR(255) NOT NULL,
   `nextheartbeat` INT NULL,
   `pendingeventid` INT,
-  PRIMARY KEY (`rmnodeid`),
-  CONSTRAINT `rmnodeid`
-    FOREIGN KEY (`rmnodeid`)
-    REFERENCES `yarn_rmnode` (`rmnodeid`)
-    ON DELETE CASCADE
-    ON UPDATE NO ACTION
+  PRIMARY KEY (`rmnodeid`)
 )ENGINE = ndbcluster DEFAULT CHARSET=latin1 PARTITION BY KEY(rmnodeid)$$
 
 delimiter $$

--- a/src/main/java/io/hops/metadata/ndb/dalimpl/yarn/NextHeartbeatClusterJ.java
+++ b/src/main/java/io/hops/metadata/ndb/dalimpl/yarn/NextHeartbeatClusterJ.java
@@ -118,14 +118,26 @@ public class NextHeartbeatClusterJ
     session.release(toRemove);
   }
 
-  public void removeById(String rmnodeId) throws StorageException {
+  public void removeById(String rmNodeId) throws StorageException {
     HopsSession session = connector.obtainSession();
-    NextHeartbeatDTO nextHB = session.find(NextHeartbeatDTO.class, rmnodeId);
+    NextHeartbeatDTO nextHB = session.find(NextHeartbeatDTO.class, rmNodeId);
     if (nextHB != null) {
-      LOG.debug("--- Removing heartbeat for node: " + rmnodeId + " ---");
       session.deletePersistent(nextHB);
     }
     session.release(nextHB);
+  }
+
+  public void removeAllById(List<String> rmNodesIds) throws StorageException {
+    HopsSession session = connector.obtainSession();
+    List<NextHeartbeatDTO> hbDTOs = new ArrayList<NextHeartbeatDTO>(rmNodesIds.size());
+    for (String rmNodeId : rmNodesIds) {
+      NextHeartbeatDTO nextHB = session.find(NextHeartbeatDTO.class, rmNodeId);
+      if (nextHB != null) {
+        hbDTOs.add(nextHB);
+      }
+    }
+    session.deletePersistentAll(hbDTOs);
+    session.release(hbDTOs);
   }
 
   private NextHeartbeatDTO createPersistable(NextHeartbeat hopNextHeartbeat,

--- a/src/main/java/io/hops/metadata/ndb/dalimpl/yarn/NextHeartbeatClusterJ.java
+++ b/src/main/java/io/hops/metadata/ndb/dalimpl/yarn/NextHeartbeatClusterJ.java
@@ -118,6 +118,16 @@ public class NextHeartbeatClusterJ
     session.release(toRemove);
   }
 
+  public void removeById(String rmnodeId) throws StorageException {
+    HopsSession session = connector.obtainSession();
+    NextHeartbeatDTO nextHB = session.find(NextHeartbeatDTO.class, rmnodeId);
+    if (nextHB != null) {
+      LOG.debug("--- Removing heartbeat for node: " + rmnodeId + " ---");
+      session.deletePersistent(nextHB);
+    }
+    session.release(nextHB);
+  }
+
   private NextHeartbeatDTO createPersistable(NextHeartbeat hopNextHeartbeat,
           HopsSession session) throws StorageException {
     NextHeartbeatDTO DTO = session.newInstance(NextHeartbeatDTO.class);

--- a/src/main/java/io/hops/metadata/ndb/dalimpl/yarn/RMNodeClusterJ.java
+++ b/src/main/java/io/hops/metadata/ndb/dalimpl/yarn/RMNodeClusterJ.java
@@ -169,12 +169,14 @@ public class RMNodeClusterJ
     NextHeartbeatClusterJ nextHBClusterJ = new NextHeartbeatClusterJ();
     HopsSession session = connector.obtainSession();
     List<RMNodeDTO> toPersist = new ArrayList<RMNodeDTO>();
+    List<String> hbToRemove = new ArrayList<String>();
     LOG.debug("--- Removing RMnode from database ---");
     for (RMNode entry : toRemove) {
       toPersist.add(session.newInstance(RMNodeDTO.class, entry.
           getNodeId()));
-      nextHBClusterJ.removeById(entry.getNodeId());
+      hbToRemove.add(entry.getNodeId());
     }
+    nextHBClusterJ.removeAllById(hbToRemove);
     session.deletePersistentAll(toPersist);
     session.release(toPersist);
   }

--- a/src/main/java/io/hops/metadata/ndb/dalimpl/yarn/RMNodeClusterJ.java
+++ b/src/main/java/io/hops/metadata/ndb/dalimpl/yarn/RMNodeClusterJ.java
@@ -177,10 +177,15 @@ public class RMNodeClusterJ
       toPersist.add(session.newInstance(RMNodeDTO.class, entry.
           getNodeId()));
       hbToRemove.add(entry.getNodeId());
-      finishedToRemove.addAll(finishedAppsClusterJ.findByRMNode(entry.getNodeId()));
+      List<FinishedApplications> tmpFinishedApps = finishedAppsClusterJ.findByRMNode(entry.getNodeId());
+      if (tmpFinishedApps != null) {
+        finishedToRemove.addAll(finishedAppsClusterJ.findByRMNode(entry.getNodeId()));
+      }
     }
     nextHBClusterJ.removeAllById(hbToRemove);
-    finishedAppsClusterJ.removeAll(finishedToRemove);
+    if (finishedToRemove.size() > 0) {
+      finishedAppsClusterJ.removeAll(finishedToRemove);
+    }
     session.deletePersistentAll(toPersist);
     session.release(toPersist);
   }

--- a/src/main/java/io/hops/metadata/ndb/dalimpl/yarn/RMNodeClusterJ.java
+++ b/src/main/java/io/hops/metadata/ndb/dalimpl/yarn/RMNodeClusterJ.java
@@ -179,7 +179,7 @@ public class RMNodeClusterJ
       hbToRemove.add(entry.getNodeId());
       List<FinishedApplications> tmpFinishedApps = finishedAppsClusterJ.findByRMNode(entry.getNodeId());
       if (tmpFinishedApps != null) {
-        finishedToRemove.addAll(finishedAppsClusterJ.findByRMNode(entry.getNodeId()));
+        finishedToRemove.addAll(tmpFinishedApps);
       }
     }
     nextHBClusterJ.removeAllById(hbToRemove);

--- a/src/main/java/io/hops/metadata/ndb/dalimpl/yarn/RMNodeClusterJ.java
+++ b/src/main/java/io/hops/metadata/ndb/dalimpl/yarn/RMNodeClusterJ.java
@@ -29,6 +29,7 @@ import io.hops.metadata.ndb.wrapper.HopsQueryDomainType;
 import io.hops.metadata.ndb.wrapper.HopsSession;
 import io.hops.metadata.yarn.TablesDef;
 import io.hops.metadata.yarn.dal.RMNodeDataAccess;
+import io.hops.metadata.yarn.entity.FinishedApplications;
 import io.hops.metadata.yarn.entity.RMNode;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -167,15 +168,19 @@ public class RMNodeClusterJ
   @Override
   public void removeAll(Collection<RMNode> toRemove) throws StorageException {
     NextHeartbeatClusterJ nextHBClusterJ = new NextHeartbeatClusterJ();
+    FinishedApplicationsClusterJ finishedAppsClusterJ = new FinishedApplicationsClusterJ();
     HopsSession session = connector.obtainSession();
     List<RMNodeDTO> toPersist = new ArrayList<RMNodeDTO>();
     List<String> hbToRemove = new ArrayList<String>();
+    List<FinishedApplications> finishedToRemove = new ArrayList<FinishedApplications>();
     for (RMNode entry : toRemove) {
       toPersist.add(session.newInstance(RMNodeDTO.class, entry.
           getNodeId()));
       hbToRemove.add(entry.getNodeId());
+      finishedToRemove.addAll(finishedAppsClusterJ.findByRMNode(entry.getNodeId()));
     }
     nextHBClusterJ.removeAllById(hbToRemove);
+    finishedAppsClusterJ.removeAll(finishedToRemove);
     session.deletePersistentAll(toPersist);
     session.release(toPersist);
   }

--- a/src/main/java/io/hops/metadata/ndb/dalimpl/yarn/RMNodeClusterJ.java
+++ b/src/main/java/io/hops/metadata/ndb/dalimpl/yarn/RMNodeClusterJ.java
@@ -170,7 +170,6 @@ public class RMNodeClusterJ
     HopsSession session = connector.obtainSession();
     List<RMNodeDTO> toPersist = new ArrayList<RMNodeDTO>();
     List<String> hbToRemove = new ArrayList<String>();
-    LOG.debug("--- Removing RMnode from database ---");
     for (RMNode entry : toRemove) {
       toPersist.add(session.newInstance(RMNodeDTO.class, entry.
           getNodeId()));

--- a/src/main/java/io/hops/metadata/ndb/dalimpl/yarn/RMNodeClusterJ.java
+++ b/src/main/java/io/hops/metadata/ndb/dalimpl/yarn/RMNodeClusterJ.java
@@ -166,11 +166,14 @@ public class RMNodeClusterJ
 
   @Override
   public void removeAll(Collection<RMNode> toRemove) throws StorageException {
+    NextHeartbeatClusterJ nextHBClusterJ = new NextHeartbeatClusterJ();
     HopsSession session = connector.obtainSession();
     List<RMNodeDTO> toPersist = new ArrayList<RMNodeDTO>();
+    LOG.debug("--- Removing RMnode from database ---");
     for (RMNode entry : toRemove) {
       toPersist.add(session.newInstance(RMNodeDTO.class, entry.
           getNodeId()));
+      nextHBClusterJ.removeById(entry.getNodeId());
     }
     session.deletePersistentAll(toPersist);
     session.release(toPersist);

--- a/src/main/resources/ndb-config.properties
+++ b/src/main/resources/ndb-config.properties
@@ -1,17 +1,17 @@
 #
 #    Do not add spaces in the file. it is also used by some deployment scripts that fail if there are redundant spaces
 #
-com.mysql.clusterj.connectstring=cloud1.sics.se
-com.mysql.clusterj.database=hop_antonis
+com.mysql.clusterj.connectstring=
+com.mysql.clusterj.database=
 com.mysql.clusterj.connection.pool.size=1
 com.mysql.clusterj.max.transactions=1024
 #com.mysql.clusterj.connection.pool.nodeids=
 
 io.hops.metadata.ndb.mysqlserver.data_source_class_name = com.mysql.jdbc.jdbc2.optional.MysqlDataSource
-io.hops.metadata.ndb.mysqlserver.host=cloud1.sics.se
-io.hops.metadata.ndb.mysqlserver.port=3307
-io.hops.metadata.ndb.mysqlserver.username=hop
-io.hops.metadata.ndb.mysqlserver.password=hop
+io.hops.metadata.ndb.mysqlserver.host=
+io.hops.metadata.ndb.mysqlserver.port=3306
+io.hops.metadata.ndb.mysqlserver.username=
+io.hops.metadata.ndb.mysqlserver.password=
 io.hops.metadata.ndb.mysqlserver.connection_pool_size=10
 
 #size of the session pool. should be altreat as big as the number of active RPC handling Threads in the system

--- a/src/main/resources/ndb-config.properties
+++ b/src/main/resources/ndb-config.properties
@@ -1,17 +1,17 @@
 #
 #    Do not add spaces in the file. it is also used by some deployment scripts that fail if there are redundant spaces
 #
-com.mysql.clusterj.connectstring=
-com.mysql.clusterj.database=
+com.mysql.clusterj.connectstring=cloud1.sics.se
+com.mysql.clusterj.database=hop_antonis
 com.mysql.clusterj.connection.pool.size=1
 com.mysql.clusterj.max.transactions=1024
 #com.mysql.clusterj.connection.pool.nodeids=
 
 io.hops.metadata.ndb.mysqlserver.data_source_class_name = com.mysql.jdbc.jdbc2.optional.MysqlDataSource
-io.hops.metadata.ndb.mysqlserver.host=
-io.hops.metadata.ndb.mysqlserver.port=3306
-io.hops.metadata.ndb.mysqlserver.username=
-io.hops.metadata.ndb.mysqlserver.password=
+io.hops.metadata.ndb.mysqlserver.host=cloud1.sics.se
+io.hops.metadata.ndb.mysqlserver.port=3307
+io.hops.metadata.ndb.mysqlserver.username=hop
+io.hops.metadata.ndb.mysqlserver.password=hop
 io.hops.metadata.ndb.mysqlserver.connection_pool_size=10
 
 #size of the session pool. should be altreat as big as the number of active RPC handling Threads in the system

--- a/src/test/java/io/hops/metadata/ndb/dalimpl/yarn/TestFullRMNodeClusterJ.java
+++ b/src/test/java/io/hops/metadata/ndb/dalimpl/yarn/TestFullRMNodeClusterJ.java
@@ -145,6 +145,36 @@ public class TestFullRMNodeClusterJ {
     org.junit.Assert.assertEquals("There should be none RMNodes persisted", 0, rmNodeResult.size());
     hbResult = (Map<String, Boolean>) queryHB.handle();
     org.junit.Assert.assertEquals("There should be none next heartbeats persisted", 0, hbResult.size());
+
+    // Add RMNode but not HB
+    populate = new LightWeightRequestHandler(YARNOperationType.TEST) {
+      @Override
+      public Object performTask() throws StorageException {
+        connector.beginTransaction();
+        connector.writeLock();
+
+        RMNodeDataAccess rmNodeDAO = (RMNodeDataAccess) storageFactory.
+                getDataAccess(RMNodeDataAccess.class);
+
+        rmNodeDAO.addAll(rmNodes);
+
+        connector.commit();
+        return null;
+      }
+    };
+    populate.handle();
+
+    rmNodeResult = (Map<String, RMNode>) queryRMNodes.handle();
+    org.junit.Assert.assertEquals("There should be three RMNodes persisted", 3, rmNodeResult.size());
+
+    hbResult = (Map<String, Boolean>) queryHB.handle();
+    org.junit.Assert.assertEquals("There should be none next heartbeats persisted", 0, hbResult.size());
+
+    removerRMNodes = new RemoveRMNodes(YARNOperationType.TEST, rmNodes);
+    removerRMNodes.handle();
+
+    rmNodeResult = (Map<String, RMNode>) queryRMNodes.handle();
+    org.junit.Assert.assertEquals("There should be none RMNodes persisted", 0, rmNodeResult.size());
   }
 
 


### PR DESCRIPTION
Remove foreign keys for tables yarn_rmnode_finishedapplications and yarn_rmnode_nextheartbeat.
Handle rows removal in RMNodeClusterJ#removeAll