### PR TITLE
Yarn formating

### DIFF
--- a/src/main/java/io/hops/metadata/ndb/ClusterjConnector.java
+++ b/src/main/java/io/hops/metadata/ndb/ClusterjConnector.java
@@ -267,10 +267,15 @@ public class ClusterjConnector implements StorageConnector<DBSession> {
    * This is called only when MiniDFSCluster wants to format the Namenode.
    */
   @Override
-  public boolean formatStorage() throws StorageException {
-    return format(true);
+  public boolean formatAllStorage() throws StorageException {
+    return formatAll(true);
   }
 
+  @Override
+  public boolean formatYarnStorage() throws StorageException {
+    return formatYarn(true);
+  }
+  
   @Override
   public boolean formatStorage(Class<? extends EntityDataAccess>... das)
       throws StorageException {
@@ -356,32 +361,18 @@ public class ClusterjConnector implements StorageConnector<DBSession> {
   }
 
   @Override
-  public boolean formatStorageNonTransactional() throws StorageException {
-    return format(false);
+  public boolean formatAllStorageNonTransactional() throws StorageException {
+    return formatAll(false);
   }
 
-  private boolean format(boolean transactional) throws StorageException {
+  @Override
+  public boolean formatYarnStorageNonTransactional() throws StorageException {
+    return formatAll(false);
+  }
+  
+  private boolean formatYarn(boolean transactional) throws StorageException{
     return format(transactional,
-        // shared
-        VariableDataAccess.class,
-        // HDFS
-        INodeDataAccess.class, BlockInfoDataAccess.class, LeaseDataAccess.class,
-        LeasePathDataAccess.class, ReplicaDataAccess.class,
-        ReplicaUnderConstructionDataAccess.class,
-        InvalidateBlockDataAccess.class, ExcessReplicaDataAccess.class,
-        PendingBlockDataAccess.class, CorruptReplicaDataAccess.class,
-        UnderReplicatedBlockDataAccess.class, HdfsLeDescriptorDataAccess.class,
-        INodeAttributesDataAccess.class, StorageIdMapDataAccess.class,
-        BlockLookUpDataAccess.class, SafeBlocksDataAccess.class,
-        MisReplicatedRangeQueueDataAccess.class, QuotaUpdateDataAccess.class,
-        EncodingStatusDataAccess.class, BlockChecksumDataAccess.class,
-        OngoingSubTreeOpsDataAccess.class,
-        MetadataLogDataAccess.class, AccessTimeLogDataAccess.class,
-        SizeLogDataAccess.class, EncodingJobsDataAccess.class,
-        RepairJobsDataAccess.class, UserDataAccess.class, GroupDataAccess.class,
-        UserGroupDataAccess.class,
-        // YARN
-        RPCDataAccess.class, HeartBeatRPCDataAccess.class,
+    RPCDataAccess.class, HeartBeatRPCDataAccess.class,
         AllocateRPCDataAccess.class,
         ApplicationStateDataAccess.class,
         UpdatedNodeDataAccess.class,
@@ -415,12 +406,48 @@ public class ClusterjConnector implements StorageConnector<DBSession> {
         RunnableAppsDataAccess.class,
         NextHeartbeatDataAccess.class,
         NodeHBResponseDataAccess.class, 
-        YarnProjectsQuotaDataAccess.class, YarnProjectsDailyCostDataAccess.class,
         ContainersCheckPointsDataAccess.class,
         CSLeafQueuesPendingAppsDataAccess.class,
-        JustFinishedContainersDataAccess.class,
-        YarnHistoryPriceDataAccess.class,
-        YarnRunningPriceDataAccess.class);
+        JustFinishedContainersDataAccess.class);
+  }
+  
+  private boolean formatHDFS(boolean transactional) throws StorageException{
+    return format(transactional,
+        INodeDataAccess.class, BlockInfoDataAccess.class, LeaseDataAccess.class,
+        LeasePathDataAccess.class, ReplicaDataAccess.class,
+        ReplicaUnderConstructionDataAccess.class,
+        InvalidateBlockDataAccess.class, ExcessReplicaDataAccess.class,
+        PendingBlockDataAccess.class, CorruptReplicaDataAccess.class,
+        UnderReplicatedBlockDataAccess.class, HdfsLeDescriptorDataAccess.class,
+        INodeAttributesDataAccess.class, StorageIdMapDataAccess.class,
+        BlockLookUpDataAccess.class, SafeBlocksDataAccess.class,
+        MisReplicatedRangeQueueDataAccess.class, QuotaUpdateDataAccess.class,
+        EncodingStatusDataAccess.class, BlockChecksumDataAccess.class,
+        OngoingSubTreeOpsDataAccess.class,
+        MetadataLogDataAccess.class, AccessTimeLogDataAccess.class,
+        SizeLogDataAccess.class, EncodingJobsDataAccess.class,
+        RepairJobsDataAccess.class, UserDataAccess.class, GroupDataAccess.class,
+        UserGroupDataAccess.class);
+  }
+  
+  private boolean formatAll(boolean transactional) throws StorageException {
+    //HDFS
+    if (!formatHDFS(transactional)) {
+      return false;
+    }
+    //YARN
+    if (!formatYarn(transactional)) {
+      return false;
+    }
+
+    // shared
+    return format(transactional,
+            VariableDataAccess.class,
+            YarnProjectsQuotaDataAccess.class,
+            YarnProjectsDailyCostDataAccess.class,
+            YarnHistoryPriceDataAccess.class,
+            YarnRunningPriceDataAccess.class
+    );
   }
 
   private boolean format(boolean transactional,

--- a/src/main/java/io/hops/metadata/ndb/ClusterjConnector.java
+++ b/src/main/java/io/hops/metadata/ndb/ClusterjConnector.java
@@ -267,7 +267,7 @@ public class ClusterjConnector implements StorageConnector<DBSession> {
    * This is called only when MiniDFSCluster wants to format the Namenode.
    */
   @Override
-  public boolean formatAllStorage() throws StorageException {
+  public boolean formatStorage() throws StorageException {
     return formatAll(true);
   }
 

--- a/src/main/java/io/hops/metadata/ndb/mysqlserver/MysqlServerConnector.java
+++ b/src/main/java/io/hops/metadata/ndb/mysqlserver/MysqlServerConnector.java
@@ -183,7 +183,7 @@ public class MysqlServerConnector implements StorageConnector<Connection> {
   }
 
   @Override
-  public boolean formatAllStorage() throws StorageException {
+  public boolean formatStorage() throws StorageException {
     throw new UnsupportedOperationException("Not supported yet.");
   }
 

--- a/src/main/java/io/hops/metadata/ndb/mysqlserver/MysqlServerConnector.java
+++ b/src/main/java/io/hops/metadata/ndb/mysqlserver/MysqlServerConnector.java
@@ -183,10 +183,15 @@ public class MysqlServerConnector implements StorageConnector<Connection> {
   }
 
   @Override
-  public boolean formatStorage() throws StorageException {
+  public boolean formatAllStorage() throws StorageException {
     throw new UnsupportedOperationException("Not supported yet.");
   }
 
+  @Override
+  public boolean formatYarnStorage() throws StorageException {
+    throw new UnsupportedOperationException("Not supported yet.");
+  }
+  
   public boolean formatStorage(Class<? extends EntityDataAccess>... das)
           throws StorageException {
     throw new UnsupportedOperationException("Not supported yet.");
@@ -223,7 +228,12 @@ public class MysqlServerConnector implements StorageConnector<Connection> {
   }
 
   @Override
-  public boolean formatStorageNonTransactional() throws StorageException {
+  public boolean formatAllStorageNonTransactional() throws StorageException {
+    throw new UnsupportedOperationException("Not supported yet.");
+  }
+
+  @Override
+  public boolean formatYarnStorageNonTransactional() throws StorageException {
     throw new UnsupportedOperationException("Not supported yet.");
   }
 

--- a/src/main/resources/ndb-config.properties
+++ b/src/main/resources/ndb-config.properties
@@ -1,17 +1,17 @@
 #
 #    Do not add spaces in the file. it is also used by some deployment scripts that fail if there are redundant spaces
 #
-com.mysql.clusterj.connectstring=cloud5
-com.mysql.clusterj.database=hop_gautier
+com.mysql.clusterj.connectstring=
+com.mysql.clusterj.database=
 com.mysql.clusterj.connection.pool.size=1
 com.mysql.clusterj.max.transactions=1024
 #com.mysql.clusterj.connection.pool.nodeids=
 
 io.hops.metadata.ndb.mysqlserver.data_source_class_name = com.mysql.jdbc.jdbc2.optional.MysqlDataSource
-io.hops.metadata.ndb.mysqlserver.host=cloud5
-io.hops.metadata.ndb.mysqlserver.port=3307
-io.hops.metadata.ndb.mysqlserver.username=hop
-io.hops.metadata.ndb.mysqlserver.password=hop
+io.hops.metadata.ndb.mysqlserver.host=
+io.hops.metadata.ndb.mysqlserver.port=3306
+io.hops.metadata.ndb.mysqlserver.username=
+io.hops.metadata.ndb.mysqlserver.password=
 io.hops.metadata.ndb.mysqlserver.connection_pool_size=10
 
 #size of the session pool. should be altreat as big as the number of active RPC handling Threads in the system


### PR DESCRIPTION
add a -format option to the resourcemanager that format only the yarn tables in the db

preparation for:
hopshadoop/hops#263

depends on:
hopshadoop/hops-metadata-dal#46