### PR TITLE
Heterogeneous storage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>io.hops.metadata</groupId>
   <artifactId>hops-metadata-dal-impl-ndb</artifactId>
-  <version>1.0-SNAPSHOT</version>
+  <version>1.1-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>hops-metadata-dal-impl-ndb</name>

--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -1,9 +1,19 @@
 delimiter $$
 
+-- Store which storages a machine has, and what types they are
+CREATE TABLE `hdfs_storages` (
+  `host_id` varchar(255) NOT NULL,
+  `storage_id` int(11) NOT NULL,
+  `storage_type` int(11) NOT NULL,
+  PRIMARY KEY (`storage_id`)
+) ENGINE=ndbcluster DEFAULT CHARSET=latin1$$
+
+delimiter $$
+
 CREATE TABLE `hdfs_block_infos` (
-  `inode_id` int(11) NOT NULL,
+  `inode_id` int(11) NOT NULL, -- file id
   `block_id` bigint(20) NOT NULL,
-  `block_index` int(11) DEFAULT NULL,
+  `block_index` int(11) DEFAULT NULL, -- position in file
   `num_bytes` bigint(20) DEFAULT NULL,
   `generation_stamp` bigint(20) DEFAULT NULL,
   `block_under_construction_state` int(11) DEFAULT NULL,
@@ -14,7 +24,6 @@ CREATE TABLE `hdfs_block_infos` (
 ) ENGINE=ndbcluster DEFAULT CHARSET=latin1
 /*!50100 PARTITION BY KEY (inode_id) */$$
 
-
 delimiter $$
 
 CREATE TABLE `hdfs_block_lookup_table` (
@@ -22,7 +31,6 @@ CREATE TABLE `hdfs_block_lookup_table` (
   `inode_id` int(11) NOT NULL,
   PRIMARY KEY (`block_id`)
 ) ENGINE=ndbcluster DEFAULT CHARSET=latin1$$
-
 
 delimiter $$
 
@@ -36,7 +44,6 @@ CREATE TABLE `hdfs_corrupt_replicas` (
 ) ENGINE=ndbcluster DEFAULT CHARSET=latin1
 /*!50100 PARTITION BY KEY (inode_id) */$$
 
-
 delimiter $$
 
 CREATE TABLE `hdfs_excess_replicas` (
@@ -48,7 +55,6 @@ CREATE TABLE `hdfs_excess_replicas` (
 ) ENGINE=ndbcluster DEFAULT CHARSET=latin1
 /*!50100 PARTITION BY KEY (inode_id) */$$
 
-
 delimiter $$
 
 CREATE TABLE `hdfs_inode_attributes` (
@@ -59,7 +65,6 @@ CREATE TABLE `hdfs_inode_attributes` (
   `diskspace` bigint(20) DEFAULT NULL,
   PRIMARY KEY (`inodeId`)
 ) ENGINE=ndbcluster DEFAULT CHARSET=latin1$$
-
 
 delimiter $$
 
@@ -84,6 +89,7 @@ CREATE TABLE `hdfs_inodes` (
   `subtree_lock_owner` bigint(20) DEFAULT NULL,
   `meta_enabled` bit(8) DEFAULT b'110000',
   `size` bigint(20) NOT NULL DEFAULT '0',
+  `storage_policy` bit(8) NOT NULL DEFAULT '0',
   PRIMARY KEY (`parent_id`,`name`),
   KEY `pidex` (`parent_id`),
   KEY `inode_idx` (`id`)
@@ -139,7 +145,6 @@ CREATE TABLE `hdfs_invalidated_blocks` (
 ) ENGINE=ndbcluster DEFAULT CHARSET=latin1
 /*!50100 PARTITION BY KEY (inode_id) */$$
 
-
 delimiter $$
 
 CREATE TABLE `hdfs_le_descriptors` (
@@ -194,7 +199,6 @@ CREATE TABLE `hdfs_misreplicated_range_queue` (
   PRIMARY KEY (`range`)
 ) ENGINE=ndbcluster DEFAULT CHARSET=latin1$$
 
-
 delimiter $$
 
 CREATE TABLE `hdfs_path_memcached` (
@@ -202,7 +206,6 @@ CREATE TABLE `hdfs_path_memcached` (
   `inodeids` varbinary(13500) NOT NULL,
   PRIMARY KEY (`path`)
 ) ENGINE=ndbcluster DEFAULT CHARSET=latin1$$
-
 
 delimiter $$
 
@@ -215,7 +218,6 @@ CREATE TABLE `hdfs_pending_blocks` (
 ) ENGINE=ndbcluster DEFAULT CHARSET=latin1
 /*!50100 PARTITION BY KEY (inode_id) */$$
 
-
 delimiter $$
 
 CREATE TABLE `hdfs_replica_under_constructions` (
@@ -226,7 +228,6 @@ CREATE TABLE `hdfs_replica_under_constructions` (
   PRIMARY KEY (`inode_id`,`block_id`,`storage_id`)
 ) ENGINE=ndbcluster DEFAULT CHARSET=latin1
 /*!50100 PARTITION BY KEY (inode_id) */$$
-
 
 delimiter $$
 
@@ -239,7 +240,6 @@ CREATE TABLE `hdfs_replicas` (
 ) ENGINE=ndbcluster DEFAULT CHARSET=latin1
 /*!50100 PARTITION BY KEY (inode_id) */$$
 
-
 delimiter $$
 
 CREATE TABLE `hdfs_safe_blocks` (
@@ -247,15 +247,14 @@ CREATE TABLE `hdfs_safe_blocks` (
   PRIMARY KEY (`id`)
 ) ENGINE=ndbcluster DEFAULT CHARSET=latin1$$
 
-
 delimiter $$
 
+-- For performance only: map String to more efficient int
 CREATE TABLE `hdfs_storage_id_map` (
   `storage_id` varchar(128) NOT NULL,
   `sid` int(11) NOT NULL,
   PRIMARY KEY (`storage_id`)
 ) ENGINE=ndbcluster DEFAULT CHARSET=latin1$$
-
 
 delimiter $$
 
@@ -269,7 +268,6 @@ CREATE TABLE `hdfs_under_replicated_blocks` (
 ) ENGINE=ndbcluster DEFAULT CHARSET=latin1
 /*!50100 PARTITION BY KEY (inode_id) */$$
 
-
 delimiter $$
 
 CREATE TABLE `hdfs_variables` (
@@ -277,7 +275,6 @@ CREATE TABLE `hdfs_variables` (
   `value` varbinary(500) NOT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=ndbcluster DEFAULT CHARSET=latin1$$
-
 
 delimiter $$
 
@@ -289,7 +286,6 @@ CREATE TABLE `hdfs_quota_update` (
   PRIMARY KEY (`inode_id`,`id`)
 ) ENGINE=ndbcluster DEFAULT CHARSET=latin1
 /*!50100 PARTITION BY KEY (inode_id) */$$
-
 
 delimiter $$
 
@@ -361,7 +357,6 @@ CREATE TABLE `yarn_applicationstate` (
 PRIMARY KEY (`applicationid`)
 ) ENGINE=ndbcluster DEFAULT CHARSET=latin1 PARTITION BY KEY(`applicationid`)$$
 
-
 delimiter $$
 
 CREATE TABLE `yarn_delegation_token` (
@@ -369,7 +364,6 @@ CREATE TABLE `yarn_delegation_token` (
   `rmdt_identifier` VARBINARY(13500) NULL,
 PRIMARY KEY (`seq_number`)
 ) ENGINE=ndbcluster DEFAULT CHARSET=latin1$$
-
 
 delimiter $$
 
@@ -379,7 +373,6 @@ CREATE TABLE `yarn_version` (
 PRIMARY KEY (`id`)
 ) ENGINE=ndbcluster DEFAULT CHARSET=latin1$$
 
-
 delimiter $$
 
 CREATE TABLE `yarn_delegation_key` (
@@ -388,7 +381,6 @@ CREATE TABLE `yarn_delegation_key` (
 PRIMARY KEY (`key`)
 ) ENGINE=ndbcluster DEFAULT CHARSET=latin1$$
 
-
 delimiter $$
 
 CREATE TABLE `yarn_sequence_number` (
@@ -396,7 +388,6 @@ CREATE TABLE `yarn_sequence_number` (
   `sequence_number` INT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=ndbcluster DEFAULT CHARSET=latin1$$
-
 
 delimiter $$
 
@@ -417,7 +408,6 @@ CREATE TABLE `yarn_applicationattemptstate` (
   ON UPDATE NO ACTION
 ) ENGINE=ndbcluster DEFAULT CHARSET=latin1 PARTITION BY KEY(`applicationid`)$$
 
-
 delimiter $$
 
 CREATE TABLE `yarn_appmaster_rpc` (
@@ -428,7 +418,6 @@ CREATE TABLE `yarn_appmaster_rpc` (
   PRIMARY KEY (`rpcid`)
 ) ENGINE=ndbcluster DEFAULT CHARSET=latin1$$
 
-
 delimiter $$
 
 CREATE TABLE `yarn_variables` (
@@ -436,7 +425,6 @@ CREATE TABLE `yarn_variables` (
   `value` INT NOT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=ndbcluster DEFAULT CHARSET=latin1$$
-
 
 delimiter $$
 
@@ -467,7 +455,6 @@ CREATE TABLE `yarn_queuemetrics` (
   PRIMARY KEY (`queue_name`)
 ) ENGINE=ndbcluster DEFAULT CHARSET=latin1$$
 
-
 delimiter $$
 
 CREATE TABLE `yarn_rmnode` (
@@ -488,7 +475,6 @@ CREATE TABLE `yarn_rmnode` (
 ENGINE = ndbcluster DEFAULT CHARSET=latin1
 PACK_KEYS = DEFAULT PARTITION BY KEY(rmnodeid)$$
 
-
 delimiter $$
 
 CREATE TABLE `yarn_resource` (
@@ -501,7 +487,6 @@ CREATE TABLE `yarn_resource` (
   PRIMARY KEY (`id`, `type`, `parent`),
   INDEX `id` (`id` ASC)
 ) ENGINE=ndbcluster DEFAULT CHARSET=latin1 PARTITION BY KEY(id)$$
-
 
 delimiter $$
 
@@ -521,7 +506,6 @@ CREATE TABLE `yarn_node` (
   ON UPDATE NO ACTION
 ) ENGINE=ndbcluster DEFAULT CHARSET=latin1 PARTITION BY KEY(nodeid) $$
 
-
 delimiter $$
 
 CREATE TABLE `yarn_ficascheduler_node` (
@@ -532,14 +516,12 @@ CREATE TABLE `yarn_ficascheduler_node` (
   PRIMARY KEY (`rmnodeid`)
 ) ENGINE=ndbcluster DEFAULT CHARSET=latin1 PARTITION BY KEY(`rmnodeid`)$$
 
-
 delimiter $$
 
 CREATE TABLE `yarn_rmctx_activenodes` (
   `rmnodeid` VARCHAR(255) NOT NULL,
   PRIMARY KEY (`rmnodeid`)
 ) ENGINE=ndbcluster DEFAULT CHARSET=latin1$$
-
 
 delimiter $$
 
@@ -556,7 +538,6 @@ CREATE TABLE `yarn_updatedcontainerinfo` (
   ON DELETE CASCADE
   ON UPDATE NO ACTION
 ) ENGINE=ndbcluster DEFAULT CHARSET=latin1 PARTITION BY KEY(`rmnodeid`)$$
-
 
 delimiter $$
 
@@ -577,12 +558,7 @@ CREATE TABLE `yarn_containerstatus` (
   ON UPDATE NO ACTION
 ) ENGINE=ndbcluster DEFAULT CHARSET=latin1 PARTITION BY KEY(`rmnodeid`)$$
 
-
-
-
 delimiter $$
-
-
 
 CREATE TABLE `yarn_justlaunchedcontainers` (
   `rmnodeid` VARCHAR(255) NOT NULL,
@@ -650,10 +626,7 @@ CREATE TABLE `yarn_containerid_toclean` (
     ON UPDATE NO ACTION
 ) ENGINE=ndbcluster DEFAULT CHARSET=latin1 PARTITION BY KEY(rmnodeid) $$
 
-
 delimiter $$
-
-
 
 CREATE TABLE `yarn_rmcontainer` (
   `containerid_id` VARCHAR(45) NOT NULL,
@@ -672,7 +645,6 @@ CREATE TABLE `yarn_rmcontainer` (
   PRIMARY KEY (`containerid_id`, `appattemptid_id`)
 ) ENGINE=ndbcluster DEFAULT CHARSET=latin1 PARTITION BY KEY(`appattemptid_id`)$$
 
-
 delimiter $$
 
 CREATE TABLE `yarn_launchedcontainers` (
@@ -686,7 +658,6 @@ CREATE TABLE `yarn_launchedcontainers` (
     ON DELETE CASCADE
     ON UPDATE NO ACTION
 ) ENGINE=ndbcluster DEFAULT CHARSET=latin1 PARTITION BY KEY(containerid_id)$$
-
 
 delimiter $$
 
@@ -703,7 +674,6 @@ CREATE TABLE `yarn_rmnode_finishedapplications` (
     ON UPDATE NO ACTION
 ) ENGINE=ndbcluster DEFAULT CHARSET=latin1 PARTITION BY KEY(applicationid) $$
 
-
 delimiter $$
 
 CREATE TABLE `yarn_schedulerapplication` (
@@ -713,10 +683,7 @@ CREATE TABLE `yarn_schedulerapplication` (
   PRIMARY KEY (`appid`)
 ) ENGINE=ndbcluster DEFAULT CHARSET=latin1 PARTITION BY KEY(appid)$$
 
-
 delimiter $$
-
-
 
 CREATE TABLE `yarn_appschedulinginfo` (
   `applicationattemptid` VARCHAR(45) NOT NULL,
@@ -737,11 +704,20 @@ CREATE TABLE `yarn_appschedulinginfo` (
     ON UPDATE NO ACTION
 ) ENGINE=ndbcluster DEFAULT CHARSET=latin1 PARTITION BY KEY(applicationattemptid)$$
 
-
-
 delimiter $$
 
+CREATE TABLE `yarn_schedulerapp_livecontainers` (
+  `applicationattemptid` VARCHAR(45) NOT NULL,
+  `rmcontainer_id` VARCHAR(45) NOT NULL,
+  PRIMARY KEY (`applicationattemptid`, `rmcontainer_id`),
+  CONSTRAINT `applicationattemptid`
+    FOREIGN KEY (`applicationattemptid`)
+    REFERENCES `yarn_appschedulinginfo` (`applicationattemptid`)
+    ON DELETE CASCADE
+    ON UPDATE NO ACTION
+) ENGINE=ndbcluster DEFAULT CHARSET=latin1 PARTITION BY KEY(`applicationattemptid`)$$
 
+delimiter $$
 
 CREATE TABLE `yarn_schedulerapp_reservedcontainers` (
   `schedulerapp_id` VARCHAR(45) NOT NULL,
@@ -751,6 +727,18 @@ CREATE TABLE `yarn_schedulerapp_reservedcontainers` (
 PRIMARY KEY (`schedulerapp_id`)
 ) ENGINE=ndbcluster DEFAULT CHARSET=latin1 PARTITION BY KEY(`schedulerapp_id`)$$
 
+delimiter $$
+
+CREATE TABLE `yarn_schedulerapp_newlyallocatedcontainers` (
+  `applicationattemptid` VARCHAR(45) NOT NULL,
+  `rmcontainer_id` VARCHAR(45) NOT NULL,
+  PRIMARY KEY (`applicationattemptid`, `rmcontainer_id`),
+  CONSTRAINT `applicationattemptid`
+    FOREIGN KEY (`applicationattemptid`)
+    REFERENCES `yarn_appschedulinginfo` (`applicationattemptid`)
+    ON DELETE CASCADE
+    ON UPDATE NO ACTION
+) ENGINE=ndbcluster DEFAULT CHARSET=latin1 PARTITION BY KEY(`applicationattemptid`)$$
 
 delimiter $$
 
@@ -761,7 +749,6 @@ CREATE TABLE `yarn_schedulerapp_schedulingopportunities` (
 PRIMARY KEY (`schedulerapp_id`)
 ) ENGINE=ndbcluster DEFAULT CHARSET=latin1$$
 
-
 delimiter $$
 
 CREATE TABLE `yarn_schedulerapp_lastscheduledcontainer` (
@@ -771,10 +758,7 @@ CREATE TABLE `yarn_schedulerapp_lastscheduledcontainer` (
 PRIMARY KEY (`schedulerapp_id`, `priority_id`)
 ) ENGINE=ndbcluster DEFAULT CHARSET=latin1$$
 
-
 delimiter $$
-
-
 
 CREATE TABLE `yarn_appschedulinginfo_blacklist` (
   `applicationattemptid` VARCHAR(45) NOT NULL,
@@ -786,7 +770,6 @@ CREATE TABLE `yarn_appschedulinginfo_blacklist` (
     ON DELETE CASCADE
     ON UPDATE NO ACTION
 ) ENGINE=ndbcluster DEFAULT CHARSET=latin1$$
-
 
 delimiter $$
 
@@ -801,16 +784,12 @@ CREATE TABLE `yarn_container` (
   #  ON UPDATE NO ACTION
 ) ENGINE=ndbcluster DEFAULT CHARSET=latin1 PARTITION BY KEY(`containerid_id`) $$
 
-
 delimiter $$
-
-
 
 CREATE TABLE `yarn_rmctx_inactivenodes` (
   `rmnodeid` VARCHAR(255) NOT NULL,
   PRIMARY KEY (`rmnodeid`)
 ) ENGINE=ndbcluster DEFAULT CHARSET=latin1 PARTITION BY KEY(rmnodeid) $$
-
 
 delimiter $$
 
@@ -827,7 +806,6 @@ CREATE TABLE `yarn_resourcerequest` (
 #    ON UPDATE NO ACTION
 ) ENGINE=ndbcluster DEFAULT CHARSET=latin1 PARTITION BY KEY(`applicationattemptid`)$$
 
-
 delimiter $$
 
 CREATE TABLE `yarn_fsscheduler_node` (
@@ -838,17 +816,13 @@ CREATE TABLE `yarn_fsscheduler_node` (
 PRIMARY KEY (`rmnodeid`)
 ) ENGINE=ndbcluster DEFAULT CHARSET=latin1$$
 
-
 delimiter $$
-
-
 
 CREATE TABLE `yarn_secret_manager_keys` (
   `id` VARCHAR(255) NOT NULL,
   `key` VARBINARY(13500) NULL,
 PRIMARY KEY (`id`)
 ) ENGINE=ndbcluster DEFAULT CHARSET=latin1$$
-
 
 delimiter $$
 

--- a/src/main/java/io/hops/metadata/ndb/ClusterjConnector.java
+++ b/src/main/java/io/hops/metadata/ndb/ClusterjConnector.java
@@ -51,6 +51,7 @@ import io.hops.metadata.hdfs.dal.ReplicaDataAccess;
 import io.hops.metadata.hdfs.dal.ReplicaUnderConstructionDataAccess;
 import io.hops.metadata.hdfs.dal.SafeBlocksDataAccess;
 import io.hops.metadata.hdfs.dal.SizeLogDataAccess;
+import io.hops.metadata.hdfs.dal.StorageDataAccess;
 import io.hops.metadata.hdfs.dal.StorageIdMapDataAccess;
 import io.hops.metadata.hdfs.dal.UnderReplicatedBlockDataAccess;
 import io.hops.metadata.hdfs.dal.UserDataAccess;
@@ -372,7 +373,27 @@ public class ClusterjConnector implements StorageConnector<DBSession> {
   
   private boolean formatYarn(boolean transactional) throws StorageException{
     return format(transactional,
-    RPCDataAccess.class, HeartBeatRPCDataAccess.class,
+        // shared
+        VariableDataAccess.class,
+        // HDFS
+        INodeDataAccess.class, BlockInfoDataAccess.class, LeaseDataAccess.class,
+        LeasePathDataAccess.class, ReplicaDataAccess.class,
+        ReplicaUnderConstructionDataAccess.class,
+        InvalidateBlockDataAccess.class, ExcessReplicaDataAccess.class,
+        PendingBlockDataAccess.class, CorruptReplicaDataAccess.class,
+        UnderReplicatedBlockDataAccess.class, HdfsLeDescriptorDataAccess.class,
+        INodeAttributesDataAccess.class, StorageIdMapDataAccess.class,
+        BlockLookUpDataAccess.class, SafeBlocksDataAccess.class,
+        MisReplicatedRangeQueueDataAccess.class, QuotaUpdateDataAccess.class,
+        EncodingStatusDataAccess.class, BlockChecksumDataAccess.class,
+        OngoingSubTreeOpsDataAccess.class,
+        MetadataLogDataAccess.class, AccessTimeLogDataAccess.class,
+        SizeLogDataAccess.class, EncodingJobsDataAccess.class,
+        RepairJobsDataAccess.class, UserDataAccess.class, GroupDataAccess.class,
+        UserGroupDataAccess.class,
+        StorageDataAccess.class,
+        // YARN
+        RPCDataAccess.class, HeartBeatRPCDataAccess.class,
         AllocateRPCDataAccess.class,
         ApplicationStateDataAccess.class,
         UpdatedNodeDataAccess.class,
@@ -457,7 +478,10 @@ public class ClusterjConnector implements StorageConnector<DBSession> {
     for (int i = 0; i < RETRIES; i++) {
       try {
         for (Class e : das) {
-          if (e == INodeDataAccess.class) {
+          if (e == StorageDataAccess.class) {
+            MysqlServerConnector
+                .truncateTable(transactional, io.hops.metadata.hdfs.TablesDef.StoragesTableDef.TABLE_NAME);
+          } else if (e == INodeDataAccess.class) {
             MysqlServerConnector
                 .truncateTable(transactional, io.hops.metadata.hdfs.TablesDef.INodeTableDef.TABLE_NAME);
           } else if (e == BlockInfoDataAccess.class) {
@@ -473,8 +497,7 @@ public class ClusterjConnector implements StorageConnector<DBSession> {
             MysqlServerConnector
                 .truncateTable(transactional, io.hops.metadata.hdfs.TablesDef.OnGoingSubTreeOpsDef.TABLE_NAME);
           } else if (e == ReplicaDataAccess.class) {
-            MysqlServerConnector
-                .truncateTable(transactional, io.hops.metadata.hdfs.TablesDef.ReplicaTableDef.TABLE_NAME);
+            MysqlServerConnector.truncateTable(transactional, io.hops.metadata.hdfs.TablesDef.ReplicaTableDef.TABLE_NAME);
           } else if (e == ReplicaUnderConstructionDataAccess.class) {
             MysqlServerConnector.truncateTable(transactional,
                 io.hops.metadata.hdfs.TablesDef.ReplicaUnderConstructionTableDef.TABLE_NAME);

--- a/src/main/java/io/hops/metadata/ndb/NdbStorageFactory.java
+++ b/src/main/java/io/hops/metadata/ndb/NdbStorageFactory.java
@@ -48,6 +48,7 @@ import io.hops.metadata.hdfs.dal.ReplicaDataAccess;
 import io.hops.metadata.hdfs.dal.ReplicaUnderConstructionDataAccess;
 import io.hops.metadata.hdfs.dal.SafeBlocksDataAccess;
 import io.hops.metadata.hdfs.dal.SizeLogDataAccess;
+import io.hops.metadata.hdfs.dal.StorageDataAccess;
 import io.hops.metadata.hdfs.dal.StorageIdMapDataAccess;
 import io.hops.metadata.hdfs.dal.UnderReplicatedBlockDataAccess;
 import io.hops.metadata.hdfs.dal.UserDataAccess;
@@ -80,6 +81,7 @@ import io.hops.metadata.ndb.dalimpl.hdfs.ReplicaUnderConstructionClusterj;
 import io.hops.metadata.ndb.dalimpl.hdfs.SafeBlocksClusterj;
 import io.hops.metadata.ndb.dalimpl.hdfs.SizeLogClusterj;
 import io.hops.metadata.ndb.dalimpl.hdfs.StorageIdMapClusterj;
+import io.hops.metadata.ndb.dalimpl.hdfs.StoragesClusterj;
 import io.hops.metadata.ndb.dalimpl.hdfs.UnderReplicatedBlockClusterj;
 import io.hops.metadata.ndb.dalimpl.hdfs.UserClusterj;
 import io.hops.metadata.ndb.dalimpl.hdfs.UserGroupClusterj;
@@ -224,8 +226,10 @@ public class NdbStorageFactory implements DalStorageFactory {
   private void initDataAccessMap() {
     dataAccessMap
             .put(RMStateVersionDataAccess.class, new RMStateVersionClusterJ());
+    dataAccessMap.put(StorageDataAccess.class, new StoragesClusterj());
     dataAccessMap
-            .put(ApplicationStateDataAccess.class, new ApplicationStateClusterJ());
+            .put(ApplicationStateDataAccess.class,
+                new ApplicationStateClusterJ());
     dataAccessMap.put(UpdatedNodeDataAccess.class, new UpdatedNodeClusterJ());
     dataAccessMap.put(ApplicationAttemptStateDataAccess.class,
             new ApplicationAttemptStateClusterJ());

--- a/src/main/java/io/hops/metadata/ndb/dalimpl/hdfs/BlockInfoClusterj.java
+++ b/src/main/java/io/hops/metadata/ndb/dalimpl/hdfs/BlockInfoClusterj.java
@@ -38,7 +38,6 @@ import io.hops.metadata.ndb.wrapper.HopsSession;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -107,7 +106,7 @@ public class BlockInfoClusterj
   @Override
   public int countAllCompleteBlocks() throws StorageException {
     return MySQLQueryHelper.countWithCriterion(TABLE_NAME,
-            String.format("%s=%d", BLOCK_UNDER_CONSTRUCTION_STATE, 0));
+        String.format("%s=%d", BLOCK_UNDER_CONSTRUCTION_STATE, 0));
   }
 
   @Override
@@ -260,14 +259,41 @@ public class BlockInfoClusterj
   public List<BlockInfo> findBlockInfosByStorageId(int storageId)
           throws StorageException {
     HopsSession session = connector.obtainSession();
-    List<ReplicaClusterj.ReplicaDTO> replicas =
-            ReplicaClusterj.getReplicas(session, storageId);
+    List<ReplicaClusterj.ReplicaDTO> replicas = ReplicaClusterj.getReplicas(session, storageId);
     long[] blockIds = new long[replicas.size()];
     int[] inodeIds = new int[replicas.size()];
     for (int i = 0; i < blockIds.length; i++) {
       blockIds[i] = replicas.get(i).getBlockId();
       inodeIds[i] = replicas.get(i).getINodeId();
     }
+    List<BlockInfo> ret = readBlockInfoBatch(session, inodeIds, blockIds);
+    session.release(replicas);
+    return ret;
+  }
+
+  @Override
+  public List<BlockInfo> findBlockInfosBySids(List<Integer> sids) throws
+      StorageException {
+    HopsSession session = connector.obtainSession();
+    HopsQueryBuilder qb = session.getQueryBuilder();
+    HopsQueryDomainType<ReplicaClusterj.ReplicaDTO> dobj =
+        qb.createQueryDefinition(ReplicaClusterj.ReplicaDTO.class);
+
+    HopsPredicate pred1 = dobj.get("storageId").in(dobj.param("sids"));
+    dobj.where(pred1);
+
+    HopsQuery<ReplicaClusterj.ReplicaDTO> query = session.createQuery(dobj);
+    query.setParameter("sids", sids);
+
+    List<ReplicaClusterj.ReplicaDTO> replicas = query.getResultList();
+
+    long[] blockIds = new long[replicas.size()];
+    int[] inodeIds = new int[replicas.size()];
+    for (int i = 0; i < blockIds.length; i++) {
+      blockIds[i] = replicas.get(i).getBlockId();
+      inodeIds[i] = replicas.get(i).getINodeId();
+    }
+
     List<BlockInfo> ret = readBlockInfoBatch(session, inodeIds, blockIds);
     session.release(replicas);
     return ret;
@@ -285,6 +311,25 @@ public class BlockInfoClusterj
     HopsSession session = connector.obtainSession();
     List<BlockInfo> blks = readBlockInfoBatch(session, inodeIds, blockIds);
     return blks;
+  }
+
+  public boolean existsOnAnyStorage(long blockId, List<Integer> sids) throws
+      StorageException {
+    HopsSession session = connector.obtainSession();
+    HopsQueryBuilder qb = session.getQueryBuilder();
+    HopsQueryDomainType<ReplicaClusterj.ReplicaDTO> dobj =
+        qb.createQueryDefinition(ReplicaClusterj.ReplicaDTO.class);
+
+    HopsPredicate pred1 = dobj.get("blockId").equal(dobj.param("blockId"));
+    HopsPredicate pred2 = dobj.get("storageId").in(dobj.param("sids"));
+    dobj.where(pred1.and(pred2));
+
+    HopsQuery<ReplicaClusterj.ReplicaDTO> query = session.createQuery(dobj);
+
+    query.setParameter("blockId", blockId);
+    query.setParameter("sids", sids);
+
+    return query.getResultList().size() > 0;
   }
 
   private List<BlockInfo> readBlockInfoBatch(final HopsSession session,

--- a/src/main/java/io/hops/metadata/ndb/dalimpl/hdfs/CorruptReplicaClusterj.java
+++ b/src/main/java/io/hops/metadata/ndb/dalimpl/hdfs/CorruptReplicaClusterj.java
@@ -52,24 +52,20 @@ public class CorruptReplicaClusterj implements TablesDef.CorruptReplicaTableDef,
     @PrimaryKey
     @Column(name = INODE_ID)
     int getINodeId();
-
     void setINodeId(int inodeId);
     
     @PrimaryKey
     @Column(name = BLOCK_ID)
     long getBlockId();
-
     void setBlockId(long bid);
 
     @PrimaryKey
     @Column(name = STORAGE_ID)
     int getStorageId();
-
-    void setStorageId(int id);
+    void setStorageId(int storageId);
     
     @Column(name = TIMESTAMP)
     long getTimestamp();
-
     void setTimestamp(long timestamp);
   }
 
@@ -112,13 +108,13 @@ public class CorruptReplicaClusterj implements TablesDef.CorruptReplicaTableDef,
   }
 
   @Override
-  public CorruptReplica findByPk(long blockId, int storageId, int inodeId)
+  public CorruptReplica findByPk(long blockId, int sid, int inodeId)
       throws StorageException {
     HopsSession dbSession = connector.obtainSession();
     Object[] keys = new Object[2];
     keys[0] = inodeId;
     keys[1] = blockId;
-    keys[2] = storageId;
+    keys[2] = sid;
 
     CorruptReplicaDTO corruptReplicaTable =
         dbSession.find(CorruptReplicaDTO.class, keys);
@@ -169,8 +165,7 @@ public class CorruptReplicaClusterj implements TablesDef.CorruptReplicaTableDef,
       throws StorageException {
     HopsSession dbSession = connector.obtainSession();
     HopsQueryBuilder qb = dbSession.getQueryBuilder();
-    HopsQueryDomainType<CorruptReplicaDTO> dobj =
-        qb.createQueryDefinition(CorruptReplicaDTO.class);
+    HopsQueryDomainType<CorruptReplicaDTO> dobj = qb.createQueryDefinition(CorruptReplicaDTO.class);
     HopsPredicate pred1 = dobj.get("iNodeId").equal(dobj.param("iNodeIdParam"));
     dobj.where(pred1);
     HopsQuery<CorruptReplicaDTO> query = dbSession.createQuery(dobj);
@@ -199,8 +194,8 @@ public class CorruptReplicaClusterj implements TablesDef.CorruptReplicaTableDef,
   }
 
   private CorruptReplica createReplica(CorruptReplicaDTO corruptReplicaTable) {
-    return new CorruptReplica(corruptReplicaTable.getBlockId(),
-        corruptReplicaTable.getStorageId(), corruptReplicaTable.getINodeId());
+    return new CorruptReplica(corruptReplicaTable.getStorageId(),
+        corruptReplicaTable.getBlockId(), corruptReplicaTable.getINodeId());
   }
 
   private List<CorruptReplica> createCorruptReplicaList(

--- a/src/main/java/io/hops/metadata/ndb/dalimpl/hdfs/ExcessReplicaClusterj.java
+++ b/src/main/java/io/hops/metadata/ndb/dalimpl/hdfs/ExcessReplicaClusterj.java
@@ -52,19 +52,16 @@ public class ExcessReplicaClusterj
     @PrimaryKey
     @Column(name = INODE_ID)
     int getINodeId();
-
     void setINodeId(int inodeID);
     
     @PrimaryKey
     @Column(name = BLOCK_ID)
     long getBlockId();
-
     void setBlockId(long storageId);
 
     @PrimaryKey
     @Column(name = STORAGE_ID)
     int getStorageId();
-
     void setStorageId(int storageId);
   }
 
@@ -102,15 +99,15 @@ public class ExcessReplicaClusterj
   }
 
   @Override
-  public List<ExcessReplica> findExcessReplicaByStorageId(int storageId)
+  public List<ExcessReplica> findExcessReplicaBySid(int sid)
       throws StorageException {
     HopsSession session = connector.obtainSession();
     HopsQueryBuilder qb = session.getQueryBuilder();
     HopsQueryDomainType<ExcessReplicaDTO> qdt =
         qb.createQueryDefinition(ExcessReplicaDTO.class);
-    qdt.where(qdt.get("storageId").equal(qdt.param("param")));
+    qdt.where(qdt.get("storageId").equal(qdt.param("sid")));
     HopsQuery<ExcessReplicaDTO> query = session.createQuery(qdt);
-    query.setParameter("param", storageId);
+    query.setParameter("sid", sid);
     List<ExcessReplicaDTO> dtos = query.getResultList();
     List<ExcessReplica> ler = createList(dtos);
     session.release(dtos);
@@ -174,13 +171,13 @@ public class ExcessReplicaClusterj
   }
 
   @Override
-  public ExcessReplica findByPK(long bId, int sId, int inodeId)
+  public ExcessReplica findByPK(long bId, int sid, int inodeId)
       throws StorageException {
     HopsSession session = connector.obtainSession();
     Object[] pk = new Object[4];
     pk[0] = inodeId;
     pk[1] = bId;
-    pk[2] = sId;
+    pk[2] = sid;
 
     ExcessReplicaDTO invTable = session.find(ExcessReplicaDTO.class, pk);
     if (invTable == null) {
@@ -217,3 +214,4 @@ public class ExcessReplicaClusterj
     exReplicaTable.setINodeId(exReplica.getInodeId());
   }
 }
+

--- a/src/main/java/io/hops/metadata/ndb/dalimpl/hdfs/INodeClusterj.java
+++ b/src/main/java/io/hops/metadata/ndb/dalimpl/hdfs/INodeClusterj.java
@@ -169,6 +169,11 @@ public class INodeClusterj implements TablesDef.INodeTableDef, INodeDataAccess<I
     long getSize();
 
     void setSize(long size);
+
+    @Column(name = STORAGE_POLICY)
+    byte getStoragePolicy();
+
+    void setStoragePolicy(byte storagePolicy);
   }
 
   private ClusterjConnector connector = ClusterjConnector.getInstance();
@@ -214,8 +219,7 @@ public class INodeClusterj implements TablesDef.INodeTableDef, INodeDataAccess<I
     HopsSession session = connector.obtainSession();
 
     HopsQueryBuilder qb = session.getQueryBuilder();
-    HopsQueryDomainType<InodeDTO> dobj =
-        qb.createQueryDefinition(InodeDTO.class);
+    HopsQueryDomainType<InodeDTO> dobj = qb.createQueryDefinition(InodeDTO.class);
     HopsPredicate pred1 = dobj.get("id").equal(dobj.param("idParam"));
     dobj.where(pred1);
 
@@ -244,10 +248,8 @@ public class INodeClusterj implements TablesDef.INodeTableDef, INodeDataAccess<I
     HopsSession session = connector.obtainSession();
 
     HopsQueryBuilder qb = session.getQueryBuilder();
-    HopsQueryDomainType<InodeDTO> dobj =
-        qb.createQueryDefinition(InodeDTO.class);
-    HopsPredicate pred1 =
-        dobj.get("parentId").equal(dobj.param("parentIDParam"));
+    HopsQueryDomainType<InodeDTO> dobj = qb.createQueryDefinition(InodeDTO.class);
+    HopsPredicate pred1 = dobj.get("parentId").equal(dobj.param("parentIDParam"));
     dobj.where(pred1);
     HopsQuery<InodeDTO> query = session.createQuery(dobj);
     query.setParameter("parentIDParam", parentId);
@@ -262,12 +264,11 @@ public class INodeClusterj implements TablesDef.INodeTableDef, INodeDataAccess<I
   public List<ProjectedINode> findInodesForSubtreeOperationsWithWriteLock(
       int parentId) throws StorageException {
     final String query = String.format(
-        "SELECT %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s FROM %s " +
-            "WHERE %s=%d LOCK IN SHARE MODE",
+        "SELECT %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s " +
+            "FROM %s WHERE %s=%d LOCK IN SHARE MODE",
         ID, NAME, PARENT_ID, PERMISSION, USER_ID, GROUP_ID, HEADER, SYMLINK,
-        QUOTA_ENABLED,
-        UNDER_CONSTRUCTION, SUBTREE_LOCKED, SUBTREE_LOCK_OWNER, SIZE, TABLE_NAME,
-        PARENT_ID, parentId);
+        QUOTA_ENABLED, UNDER_CONSTRUCTION, SUBTREE_LOCKED, SUBTREE_LOCK_OWNER,
+        SIZE, STORAGE_POLICY, TABLE_NAME, PARENT_ID, parentId);
     ArrayList<ProjectedINode> resultList;
     try {
       Connection conn = mysqlConnector.obtainSession();
@@ -286,7 +287,8 @@ public class INodeClusterj implements TablesDef.INodeTableDef, INodeDataAccess<I
                 result.getBoolean(UNDER_CONSTRUCTION),
                 result.getBoolean(SUBTREE_LOCKED),
                 result.getLong(SUBTREE_LOCK_OWNER),
-                result.getLong(SIZE)));
+                result.getLong(SIZE),
+                result.getByte(STORAGE_POLICY)));
       }
     } catch (SQLException ex) {
       throw HopsSQLExceptionHelper.wrap(ex);
@@ -438,19 +440,27 @@ public class INodeClusterj implements TablesDef.INodeTableDef, INodeDataAccess<I
 
 
   private INode convert(InodeDTO persistable) {
-    INode node = new INode(persistable.getId(), persistable.getName(),
+    INode node = new INode(persistable.getId(),
+        persistable.getName(),
         persistable.getParentId(),
         NdbBoolean.convert(persistable.getQuotaEnabled()),
-        persistable.getModificationTime(), persistable.getATime(),
-        persistable.getUserID(), persistable.getGroupID(),
-        persistable.getPermission(), persistable.getUnderConstruction(),
-        persistable.getClientName(), persistable.getClientMachine(),
-        persistable.getClientNode(), persistable.getGenerationStamp(),
-        persistable.getHeader(), persistable.getSymlink(),
+        persistable.getModificationTime(),
+        persistable.getATime(),
+        persistable.getUserID(),
+        persistable.getGroupID(),
+        persistable.getPermission(),
+        persistable.getUnderConstruction(),
+        persistable.getClientName(),
+        persistable.getClientMachine(),
+        persistable.getClientNode(),
+        persistable.getGenerationStamp(),
+        persistable.getHeader(),
+        persistable.getSymlink(),
         NdbBoolean.convert(persistable.getSubtreeLocked()),
         persistable.getSubtreeLockOwner(),
         NdbBoolean.convert(persistable.getMetaEnabled()),
-        persistable.getSize());
+        persistable.getSize(),
+        persistable.getStoragePolicy());
     return node;
   }
 
@@ -475,6 +485,7 @@ public class INodeClusterj implements TablesDef.INodeTableDef, INodeDataAccess<I
     persistable.setSubtreeLockOwner(inode.getSubtreeLockOwner());
     persistable.setMetaEnabled(NdbBoolean.convert(inode.isMetaEnabled()));
     persistable.setSize(inode.getFileSize());
+    persistable.setStoragePolicy(inode.getStoragePolicy());
   }
 
   private void explain(HopsQuery<InodeDTO> query) {

--- a/src/main/java/io/hops/metadata/ndb/dalimpl/hdfs/ReplicaUnderConstructionClusterj.java
+++ b/src/main/java/io/hops/metadata/ndb/dalimpl/hdfs/ReplicaUnderConstructionClusterj.java
@@ -142,6 +142,25 @@ public class ReplicaUnderConstructionClusterj
     return convertAndRelease(session, query.getResultList());
   }
 
+  @Override
+  public void removeByBlockIdAndInodeId(long blockId, int inodeId) throws
+      StorageException {
+    HopsSession session = connector.obtainSession();
+    HopsQueryBuilder qb = session.getQueryBuilder();
+
+    HopsQueryDomainType<ReplicaUcDTO> qdt = qb.createQueryDefinition
+        (ReplicaUcDTO.class);
+    HopsPredicate pred1 = qdt.get("blockId").equal(qdt.param("blockIdParam"));
+    HopsPredicate pred2 = qdt.get("iNodeId").equal(qdt.param("iNodeIdParam"));
+    qdt.where(pred1.and(pred2));
+
+    HopsQuery<ReplicaUcDTO> query = session.createQuery(qdt);
+    query.setParameter("blockIdParam", blockId);
+    query.setParameter("iNodeIdParam", inodeId);
+
+    query.deletePersistentAll();
+  }
+
   private List<ReplicaUnderConstruction> convertAndRelease(HopsSession session,
       List<ReplicaUcDTO> replicaUc) throws StorageException {
     List<ReplicaUnderConstruction> replicas =

--- a/src/main/java/io/hops/metadata/ndb/dalimpl/hdfs/StoragesClusterj.java
+++ b/src/main/java/io/hops/metadata/ndb/dalimpl/hdfs/StoragesClusterj.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (C) 2015 hops.io.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.hops.metadata.ndb.dalimpl.hdfs;
+
+import com.mysql.clusterj.annotation.Column;
+import com.mysql.clusterj.annotation.PersistenceCapable;
+import com.mysql.clusterj.annotation.PrimaryKey;
+import io.hops.exception.StorageException;
+import io.hops.metadata.hdfs.TablesDef;
+import io.hops.metadata.hdfs.dal.StorageDataAccess;
+import io.hops.metadata.hdfs.entity.Storage;
+import io.hops.metadata.ndb.ClusterjConnector;
+import io.hops.metadata.ndb.wrapper.HopsPredicate;
+import io.hops.metadata.ndb.wrapper.HopsQuery;
+import io.hops.metadata.ndb.wrapper.HopsQueryBuilder;
+import io.hops.metadata.ndb.wrapper.HopsQueryDomainType;
+import io.hops.metadata.ndb.wrapper.HopsSession;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public class StoragesClusterj implements TablesDef.StoragesTableDef,
+    StorageDataAccess<Storage> {
+
+  private ClusterjConnector connector = ClusterjConnector.getInstance();
+
+  @PersistenceCapable(table = TABLE_NAME)
+  public interface StorageDTO {
+    @PrimaryKey
+    @Column(name = STORAGE_ID)
+    int getStorageId();
+    void setStorageId(int sid);
+
+    @Column(name = HOST_ID)
+    String getHostId();
+    void setHostId(String hostId);
+
+    @Column(name = STORAGE_TYPE)
+    int getStorageType();
+    void setStorageType(int storageType);
+  }
+
+  @Override
+  public void prepare(Collection<Storage> collection,
+      Collection<Storage> collection1) throws StorageException {
+
+  }
+
+  @Override
+  public void add(Storage s) throws StorageException {
+    HopsSession session = connector.obtainSession();
+    StorageDTO sdto = session.newInstance(StorageDTO.class);
+    sdto.setStorageId(s.getStorageID());
+    sdto.setHostId(s.getHostID());
+    sdto.setStorageType(s.getStorageType());
+    session.savePersistent(sdto);
+    session.release(sdto);
+  }
+
+  @Override
+  public Storage findByPk(int storageId) throws StorageException {
+    HopsSession session = connector.obtainSession();
+    StorageDTO sdto = session.find(StorageDTO.class, storageId);
+    if (sdto == null) {
+      return null;
+    }
+    return convertAndRelease(session, sdto);
+  }
+
+  @Override
+  public List<Storage> findByHostUuid(String uuid) throws StorageException {
+    HopsSession session = connector.obtainSession();
+    HopsQueryBuilder qb = session.getQueryBuilder();
+    HopsQueryDomainType<StorageDTO> dobj =
+        qb.createQueryDefinition(StorageDTO.class);
+
+    HopsPredicate pred1 = dobj.get("hostId").equal(dobj.param("hostId"));
+
+    dobj.where(pred1);
+
+    HopsQuery<StorageDTO> query = session.createQuery(dobj);
+    query.setParameter("hostId", uuid);
+
+    return convertAndRelease(session, query.getResultList());
+  }
+
+  @Override
+  public Collection<Storage> findAll() throws StorageException {
+    HopsSession session = connector.obtainSession();
+    HopsQueryBuilder qb = session.getQueryBuilder();
+    HopsQueryDomainType<StorageDTO> qdt =
+        qb.createQueryDefinition(StorageDTO.class);
+    HopsQuery<StorageDTO> q = session.createQuery(qdt);
+    return convertAndRelease(session, q.getResultList());
+  }
+
+  /**
+   * Convert a list of storageDTO's into storages
+   */
+  private List<Storage> convertAndRelease(HopsSession session,
+      List<StorageDTO> dtos) throws StorageException {
+    ArrayList<Storage> list = new ArrayList<Storage>(dtos.size());
+
+    for (StorageDTO dto : dtos) {
+      list.add(create(dto));
+      session.release(dto);
+    }
+
+    return list;
+  }
+
+  private Storage convertAndRelease(HopsSession session, StorageDTO sdto)
+      throws StorageException {
+    Storage storage = new Storage(sdto.getStorageId(), sdto.getHostId(), sdto
+        .getStorageType());
+    session.release(sdto);
+    return storage;
+  }
+
+  private Storage create(StorageDTO dto) {
+    Storage storage = new Storage(
+        dto.getStorageId(),
+        dto.getHostId(),
+        dto.getStorageType());
+    return storage;
+  }
+}

--- a/src/main/resources/ndb-config.properties
+++ b/src/main/resources/ndb-config.properties
@@ -1,17 +1,30 @@
 #
 #    Do not add spaces in the file. it is also used by some deployment scripts that fail if there are redundant spaces
 #
-com.mysql.clusterj.connectstring=
-com.mysql.clusterj.database=
+com.mysql.clusterj.connectstring=cloud1.sics.se
+com.mysql.clusterj.database=hop_bram_vm
 com.mysql.clusterj.connection.pool.size=1
 com.mysql.clusterj.max.transactions=1024
 #com.mysql.clusterj.connection.pool.nodeids=
 
-io.hops.metadata.ndb.mysqlserver.data_source_class_name = com.mysql.jdbc.jdbc2.optional.MysqlDataSource
-io.hops.metadata.ndb.mysqlserver.host=
-io.hops.metadata.ndb.mysqlserver.port=3306
-io.hops.metadata.ndb.mysqlserver.username=
-io.hops.metadata.ndb.mysqlserver.password=
+io.hops.metadata.ndb.mysqlserver.data_source_class_name=com.mysql.jdbc.jdbc2.optional.MysqlDataSource
+io.hops.metadata.ndb.mysqlserver.host=cloud1.sics.se
+io.hops.metadata.ndb.mysqlserver.port=3307
+io.hops.metadata.ndb.mysqlserver.username=hop
+io.hops.metadata.ndb.mysqlserver.password=hop
+
+#com.mysql.clusterj.connectstring=192.168.0.21
+#io.hops.metadata.ndb.mysqlserver.host=192.168.0.21
+#io.hops.metadata.ndb.mysqlserver.port=3306
+#io.hops.metadata.ndb.mysqlserver.username=kthfs
+#io.hops.metadata.ndb.mysqlserver.password=kthfs
+
+#com.mysql.clusterj.connectstring=192.168.168.36
+#io.hops.metadata.ndb.mysqlserver.host=192.168.168.36
+#io.hops.metadata.ndb.mysqlserver.port=3306
+#io.hops.metadata.ndb.mysqlserver.username=kthfs
+#io.hops.metadata.ndb.mysqlserver.password=kthfs
+
 io.hops.metadata.ndb.mysqlserver.connection_pool_size=10
 
 #size of the session pool. should be altreat as big as the number of active RPC handling Threads in the system
@@ -21,3 +34,4 @@ io.hops.session.pool.size=1000
 #use smaller values if using java 6.
 #if you use java 7 or higer then use G1GC and there is no need to close sessions. use Int.MAX_VALUE
 io.hops.session.reuse.count=2147483647
+


### PR DESCRIPTION
All commits to implement heterogeneous storage for Hops.

Up for review. The hops repo still has some bugs, but comments on this one are welcome!

###### Important

The version is updated from 1.0 to 1.1

This means you can have both this version and the "old" version running on the same machine. Hops will automatically select the right one, and there is no need to recompile each time you switch between the "old" Hops and the version that has heterogeneous storage.

###### Squashed the following commits:


* Add Storages table for HDFS-4987

* Add findBlockInfosByHostId

* Renamed find to findByHostUuid

* Use datanodeUuid instead of storageId for excessreplicas

* Identify corrupt/invalidated blocks by datanode UUID

* Add DNuuid to excess/invalidates/corrupt

* commit for testing

* Use variable to refer to field name

* Fix field name

* Removed datanode_uuid from tables
Deleting now works

* Search by sid

* Fix some storage/storageId stuff

* Lookups per DN

* Fix Tuple did not exist

* Fix removal of replicaUnderConstruction

* Adding storage policy ID to inode table

* Some reformatting and bugfix