### PR TITLE
[HOPS-161] Fixed long TestsSmallFileCreation

### DIFF
--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -110,7 +110,7 @@ BEGIN
 
 	SELECT count(LOGFILE_GROUP_NAME) INTO lc FROM INFORMATION_SCHEMA.FILES where LOGFILE_GROUP_NAME="lg_1";
 	IF (lc = 0) THEN
-	    CREATE LOGFILE GROUP lg_1 ADD UNDOFILE 'undo_log_0.log' INITIAL_SIZE = 2048M ENGINE ndbcluster;
+	    CREATE LOGFILE GROUP lg_1 ADD UNDOFILE 'undo_log_0.log' INITIAL_SIZE = 128M ENGINE ndbcluster;
 	ELSE
 		select "The LogFile has already been created" as "";
 	END IF;
@@ -118,7 +118,7 @@ BEGIN
 
 	SELECT count(TABLESPACE_NAME) INTO tc FROM INFORMATION_SCHEMA.FILES where TABLESPACE_NAME="ts_1";
 	IF (tc = 0) THEN
-		CREATE TABLESPACE ts_1 ADD datafile 'ts_1_data_file_0.dat' use LOGFILE GROUP lg_1 INITIAL_SIZE = 2048M  ENGINE ndbcluster;
+		CREATE TABLESPACE ts_1 ADD datafile 'ts_1_data_file_0.dat' use LOGFILE GROUP lg_1 INITIAL_SIZE = 128M  ENGINE ndbcluster;
 	ELSE
 		select "The DataFile has already been created" as "";
 	END IF;


### PR DESCRIPTION
[Hops-161] Fixed Test SmallFileCreation long test duration

FIX (Works if there is only one HopsFS schema)
1) run the "drop-disk-table.sh" 
2) Drop the schema
3) Import the schema again

If the database has multiple HopsFS schemas then the "drop-disk-table.sh" will fail to delete the Log file group as is it shared between all the HopsFS schemas. Either run the script for all users or just re-init the database and manually delete the "ts_1_data_file_0.dat" and "undo_log_0.log" files in the ndb_data dir.