### PR TITLE
[HOPS-651] truncate table when updating to use System.currentTime ins…

### DIFF
--- a/schema/update-schema_2.8.2.4_to_2.8.2.5.sql
+++ b/schema/update-schema_2.8.2.4_to_2.8.2.5.sql
@@ -69,3 +69,5 @@ insert into hdfs_variables (id, value) select 32, "" where (select count(*) from
 insert into hdfs_variables (id, value) select 33, "" where (select count(*) from hdfs_variables)>0;
 
 insert into hdfs_variables (id, value) select 34, "" where (select count(*) from hdfs_variables)>0;
+
+truncate table hdfs_retry_cache_entry;


### PR DESCRIPTION
…tead of System.nanoTime for retry cache.

## Make sure there is no duplicate PR for this issue

* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added and passed (for bug fixes / features)
- [x] HOPS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit
- [x] The commit message has the following format: [HOPS-XXX] message

* **Post a link to the associated JIRA issue**
https://hopshadoop.atlassian.net/browse/HOPS-651

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix

* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**: