### PR TITLE
[HOPS-998] Do not monitor DB index memory resource as it is deprecated in NDB 7.6.2. 

### DIFF
--- a/src/main/java/io/hops/metadata/ndb/mysqlserver/MysqlServerConnector.java
+++ b/src/main/java/io/hops/metadata/ndb/mysqlserver/MysqlServerConnector.java
@@ -332,7 +332,7 @@ public class MysqlServerConnector implements StorageConnector<Connection> {
   
   public static boolean hasResources(final double threshold) throws StorageException {
     return MySQLQueryHelper.execute("SELECT memory_type, used, total FROM " +
-            "ndbinfo.memoryusage",
+            "ndbinfo.memoryusage where memory_type = \"Data memory\"",
         new MySQLQueryHelper.ResultSetHandler<Boolean>() {
           @Override
           public Boolean handle(ResultSet result)


### PR DESCRIPTION
Do not monitor DB index memory resource as it is deprecated in NDB 7.6.2. 

## Make sure there is no duplicate PR for this issue

* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added and passed (for bug fixes / features)
- [x] HOPS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit
- [x] The commit message has the following format: [HOPS-XXX] message

* **Post a link to the associated JIRA issue**
https://hopshadoop.atlassian.net/browse/HOPS-998

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix

* **What is the new behavior (if this is a feature change)?**
we do not have to monitor index memory as it is manged by NDB now 

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**: