### PR TITLE
[HOPS-6] Availability Zone Awareness support for HopsFS

### DIFF
--- a/schema/create-tables.sh
+++ b/schema/create-tables.sh
@@ -4,4 +4,5 @@ mysql --host=$1 --port=$2 -u $3 -p$4 $5 < update-schema_2.8.2.2_to_2.8.2.3.sql &
 mysql --host=$1 --port=$2 -u $3 -p$4 $5 < update-schema_2.8.2.3_to_2.8.2.4.sql &&
 mysql --host=$1 --port=$2 -u $3 -p$4 $5 < update-schema_2.8.2.4_to_2.8.2.5.sql &&
 mysql --host=$1 --port=$2 -u $3 -p$4 $5 < update-schema_2.8.2.5_to_2.8.2.6.sql &&
-mysql --host=$1 --port=$2 -u $3 -p$4 $5 < update-schema_2.8.2.6_to_2.8.2.7.sql
+mysql --host=$1 --port=$2 -u $3 -p$4 $5 < update-schema_2.8.2.6_to_2.8.2.7.sql &&
+mysql --host=$1 --port=$2 -u $3 -p$4 $5 < update-schema_2.8.2.7_to_2.8.2.8.sql

--- a/schema/update-schema_2.8.2.7_to_2.8.2.8.sql
+++ b/schema/update-schema_2.8.2.7_to_2.8.2.8.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `hdfs_le_descriptors` ADD COLUMN `location_domain_id` tinyint(4) default 0;
+ALTER TABLE `yarn_le_descriptors` ADD COLUMN `location_domain_id` tinyint(4) default 0;

--- a/src/main/java/io/hops/metadata/ndb/dalimpl/election/HdfsLeaderClusterj.java
+++ b/src/main/java/io/hops/metadata/ndb/dalimpl/election/HdfsLeaderClusterj.java
@@ -68,6 +68,13 @@ public class HdfsLeaderClusterj extends LeDescriptorClusterj
 
     @Override
     void setHttpAddress(String httpAddress);
+    
+    @Column(name = LOCATION_DOMAIN_ID)
+    @Override
+    byte getLocationDomainId();
+    
+    @Override
+    void setLocationDomainId(byte domainId);
   }
 
   @Override
@@ -76,7 +83,8 @@ public class HdfsLeaderClusterj extends LeDescriptorClusterj
       throw new InvalidParameterException("Psrtition key should be zero");
     }
     return new LeDescriptor.HdfsLeDescriptor(lTable.getId(),
-        lTable.getCounter(), lTable.getHostname(), lTable.getHttpAddress());
+        lTable.getCounter(), lTable.getHostname(), lTable.getHttpAddress(),
+        lTable.getLocationDomainId());
   }
 
   public HdfsLeaderClusterj() {

--- a/src/main/java/io/hops/metadata/ndb/dalimpl/election/LeDescriptorClusterj.java
+++ b/src/main/java/io/hops/metadata/ndb/dalimpl/election/LeDescriptorClusterj.java
@@ -61,6 +61,10 @@ public abstract class LeDescriptorClusterj
     String getHttpAddress();
 
     void setHttpAddress(String httpAddress);
+    
+    byte getLocationDomainId();
+    
+    void setLocationDomainId(byte domainId);
   }
 
   public LeDescriptorClusterj(Class dto) {
@@ -146,5 +150,6 @@ public abstract class LeDescriptorClusterj
     lTable.setHostname(leader.getRpcAddresses());
     lTable.setHttpAddress(leader.getHttpAddress());
     lTable.setPartitionVal(leader.getPartitionVal());
+    lTable.setLocationDomainId(leader.getLocationDomainId());
   }
 }

--- a/src/main/java/io/hops/metadata/ndb/dalimpl/election/YarnLeaderClusterj.java
+++ b/src/main/java/io/hops/metadata/ndb/dalimpl/election/YarnLeaderClusterj.java
@@ -58,6 +58,13 @@ public class YarnLeaderClusterj extends LeDescriptorClusterj
     String getHttpAddress();
 
     void setHttpAddress(String httpAddress);
+  
+    @Column(name = LOCATION_DOMAIN_ID)
+    @Override
+    byte getLocationDomainId();
+  
+    @Override
+    void setLocationDomainId(byte domainId);
 
   }
 
@@ -67,7 +74,8 @@ public class YarnLeaderClusterj extends LeDescriptorClusterj
       throw new InvalidParameterException("Psrtition key should be zero");
     }
     return new LeDescriptor.YarnLeDescriptor(lTable.getId(),
-        lTable.getCounter(), lTable.getHostname(), lTable.getHttpAddress());
+        lTable.getCounter(), lTable.getHostname(), lTable.getHttpAddress(),
+        lTable.getLocationDomainId());
   }
 
   public YarnLeaderClusterj() {


### PR DESCRIPTION
## Make sure there is no duplicate PR for this issue

* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added and passed (for bug fixes / features)
- [x] HOPS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit
- [x] The commit message has the following format: [HOPS-XXX] message

* **Post a link to the associated JIRA issue**
https://hopshadoop.atlassian.net/browse/HOPS-6

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature 

* **What is the new behavior (if this is a feature change)?**
Admins can assign a namenode to a specific availability zone using a new configuration parameter in hdfs-site. Users can also assign their clients to a specific availability zone to enforce using a namenode from the same availability zone.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**: