### PR TITLE
[HOPS-1343] Recover inode if reset subtree lock fails

### DIFF
--- a/schema/update-schema_2.8.2.7_to_2.8.2.8.sql
+++ b/schema/update-schema_2.8.2.7_to_2.8.2.8.sql
@@ -72,3 +72,11 @@ ALTER TABLE `hdfs_metadata_log` CHANGE `inode_parent_id` `pk2` bigint(20);
 ALTER TABLE `hdfs_metadata_log` CHANGE `inode_name` `pk3` varchar(255) COLLATE latin1_general_cs NOT NULL DEFAULT '';
 
 ALTER TABLE hdfs_active_block_reports ADD (`nn_address` varchar(128) COLLATE latin1_general_cs NOT NULL);
+
+ALTER TABLE `hdfs_on_going_sub_tree_ops` ADD COLUMN `start_time` bigint(20) NOT NULL;
+
+ALTER TABLE `hdfs_on_going_sub_tree_ops` ADD COLUMN `async_lock_recovery_time` bigint(20) NOT NULL DEFAULT '0';
+
+ALTER TABLE `hdfs_on_going_sub_tree_ops` ADD COLUMN `user` varchar(256) NOT NULL DEFAULT '';
+
+ALTER TABLE `hdfs_on_going_sub_tree_ops` ADD COLUMN `inode_id` bigint(20) NOT NULL DEFAULT '0';


### PR DESCRIPTION
[HOPS-1344] Recover inode if reset subtree lock fails
[HOPS-1344] Add lock and path information for failed operation
[HOPS-1345] Add more information in on_going_subtree_ops table

## Make sure there is no duplicate PR for this issue

* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added and passed (for bug fixes / features)
- [x] HOPS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit
- [x] The commit message has the following format: [HOPS-XXX] message

* **Post a link to the associated JIRA issue**
https://hopshadoop.atlassian.net/browse/HOPS-1343
https://hopshadoop.atlassian.net/browse/HOPS-1344
https://hopshadoop.atlassian.net/browse/HOPS-1345
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**: