### PR TITLE
[HOPS-1348] alter xattr table - decrease size of xattr value

### DIFF
--- a/schema/update-schema_2.8.2.7_to_2.8.2.8.sql
+++ b/schema/update-schema_2.8.2.7_to_2.8.2.8.sql
@@ -60,7 +60,7 @@ CREATE TABLE `hdfs_xattrs` (
   `inode_id` bigint(20) NOT NULL,
   `namespace` tinyint(4) NOT NULL,
   `name` varchar(255) COLLATE latin1_general_cs NOT NULL,
-  `value` varchar(13730) COLLATE latin1_general_cs DEFAULT '',
+  `value` varchar(13500) COLLATE latin1_general_cs DEFAULT '',
   PRIMARY KEY (`inode_id`,`namespace`,`name`)
 ) ENGINE=ndbcluster DEFAULT CHARSET=latin1 COLLATE=latin1_general_cs COMMENT='NDB_TABLE=READ_BACKUP=1'
 /*!50100 PARTITION BY KEY (inode_id) */;


### PR DESCRIPTION
## Make sure there is no duplicate PR for this issue

* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added and passed (for bug fixes / features)
- [x] HOPS JIRA issue has been opened for this PR
- [ ] All commits have been squashed down to a single commit
- [ ] The commit message has the following format: [HOPS-XXX] message

* **Post a link to the associated JIRA issue**
https://hopshadoop.atlassian.net/projects/HOPS/issues/HOPS-1348

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature change

* **What is the new behavior (if this is a feature change)?**
feature change - XAttr

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
It changes the db. If anyone used XAttr and added values of max size - this would be a big breaking change.

* **Other information**:
https://github.com/hopshadoop/hops-metadata-dal/pull/165
https://github.com/hopshadoop/hops/pull/687

