### PR TITLE
[HOPS-1365] fix getBlocks to be faster and not kill the DB

### DIFF
--- a/src/main/java/io/hops/metadata/ndb/mysqlserver/MySQLQueryHelper.java
+++ b/src/main/java/io/hops/metadata/ndb/mysqlserver/MySQLQueryHelper.java
@@ -136,7 +136,7 @@ public class MySQLQueryHelper {
     });
   }
   
-    private static long executeLongAggrQuery(final String query)
+    public static long executeLongAggrQuery(final String query)
       throws StorageException {
     return execute(query, new ResultSetHandler<Long>() {
       @Override


### PR DESCRIPTION
## Make sure there is no duplicate PR for this issue

* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added and passed (for bug fixes / features)
- [x] HOPS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit
- [x] The commit message has the following format: [HOPS-XXX] message

* **Post a link to the associated JIRA issue**
https://hopshadoop.atlassian.net/browse/HOPS-1365

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**:
depends on hopshadoop/hops-metadata-dal#168