### PR TITLE
[HOPS-1588] truncate leader election tables on upgrade

### DIFF
--- a/schema/update-schema_3.2.0.0_to_3.2.0.1.sql
+++ b/schema/update-schema_3.2.0.0_to_3.2.0.1.sql
@@ -1,0 +1,3 @@
+truncate hdfs_le_descriptors;
+
+truncate yarn_le_descriptors;


### PR DESCRIPTION
## Make sure there is no duplicate PR for this issue

* **Please check if the PR fulfills these requirements**
- [] Tests for the changes have been added and passed (for bug fixes / features)
- [x] HOPS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit
- [x] The commit message has the following format: [HOPS-XXX] message

* **Post a link to the associated JIRA issue**
https://hopshadoop.atlassian.net/jira/software/c/projects/HOPS/issues/HOPS-1588/?filter=allissues

The leader namenode recreate these missing rows when a cluster restart is detected. Currently we detect cluster restart using the leader election tables. If the tables are empty then it means all the namenode(s) were shut down and it is safe for the leader to recreate these missing rows. During upgrades we have some rows left in the leader election tables by the previous version of Hops. Simply truncating the leader election tables will fix this problem.
