### PR TITLE
RONDB-519: Bump RonDB version to 22.10.1

### DIFF
--- a/dev-support/docker/Dockerfile
+++ b/dev-support/docker/Dockerfile
@@ -16,7 +16,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 
-FROM ubuntu:focal
+FROM ubuntu:jammy
 
 WORKDIR /root
 
@@ -36,6 +36,7 @@ RUN apt-get -q update \
         maven \
         openjdk-8-jdk \
         sudo \
+        openssl \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>com.mysql.ndb</groupId>
       <artifactId>clusterj-rondb</artifactId>
-      <version>21.04.15</version>
+      <version>22.10.1-SNAPSHOT</version>
     </dependency>
 
     <dependency>
@@ -48,7 +48,7 @@
     <dependency>
       <groupId>com.mysql.ndb</groupId>
       <artifactId>clusterj-native</artifactId>
-      <version>21.04.12</version>
+      <version>22.10.1</version>
       <classifier>natives-linux</classifier>
       <scope>test</scope>
     </dependency>
@@ -152,7 +152,7 @@
                 <artifactItem>
                   <groupId>com.mysql.ndb</groupId>
                   <artifactId>clusterj-native</artifactId>
-                  <version>21.04.12</version>
+                  <version>22.10.1</version>
                   <classifier>natives-linux</classifier>
                   <type>jar</type>
                   <overWrite>true</overWrite>


### PR DESCRIPTION
RONDB-519: Bump RonDB version to 22.10.1